### PR TITLE
refact(webhook): add validation for new fields in cspc

### DIFF
--- a/pkg/webhook/configuration.go
+++ b/pkg/webhook/configuration.go
@@ -25,7 +25,7 @@ import (
 	"github.com/openebs/api/pkg/util"
 	"github.com/openebs/maya/pkg/version"
 	"github.com/pkg/errors"
-	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistration "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
@@ -59,7 +59,7 @@ type client struct {
 
 type transformSvcFunc func(*corev1.Service)
 type transformSecretFunc func(*corev1.Secret)
-type transformConfigFunc func(*v1beta1.ValidatingWebhookConfiguration)
+type transformConfigFunc func(*admissionregistration.ValidatingWebhookConfiguration)
 
 var (
 	// TimeoutSeconds specifies the timeout for this webhook. After the timeout passes,
@@ -68,7 +68,7 @@ var (
 	// The timeout value must be between 1 and 30 seconds.
 	five = int32(5)
 	// Ignore means that an error calling the webhook is ignored.
-	Ignore = v1beta1.Ignore
+	Ignore = admissionregistration.Ignore
 	// transformation function lists to upgrade webhook resources
 	transformSecret = []transformSecretFunc{}
 	transformSvc    = []transformSvcFunc{}
@@ -157,35 +157,35 @@ func (c *client) createAdmissionService(
 		)
 	}
 
-	// sideEffectClass := v1beta1.SideEffectClassNoneOnDryRun
+	// sideEffectClass := admissionregistration.SideEffectClassNoneOnDryRun
 
-	webhookHandler := v1beta1.ValidatingWebhook{
+	webhookHandler := admissionregistration.ValidatingWebhook{
 		Name: webhookHandlerName,
-		Rules: []v1beta1.RuleWithOperations{{
-			Operations: []v1beta1.OperationType{
-				v1beta1.Create,
-				v1beta1.Delete,
+		Rules: []admissionregistration.RuleWithOperations{{
+			Operations: []admissionregistration.OperationType{
+				admissionregistration.Create,
+				admissionregistration.Delete,
 			},
-			Rule: v1beta1.Rule{
+			Rule: admissionregistration.Rule{
 				APIGroups:   []string{"*"},
 				APIVersions: []string{"*"},
 				Resources:   []string{"persistentvolumeclaims"},
 			},
 		},
 			{
-				Operations: []v1beta1.OperationType{
-					v1beta1.Create,
-					v1beta1.Update,
-					v1beta1.Delete,
+				Operations: []admissionregistration.OperationType{
+					admissionregistration.Create,
+					admissionregistration.Update,
+					admissionregistration.Delete,
 				},
-				Rule: v1beta1.Rule{
+				Rule: admissionregistration.Rule{
 					APIGroups:   []string{"*"},
 					APIVersions: []string{"*"},
 					Resources:   []string{"cstorpoolclusters"},
 				},
 			}},
-		ClientConfig: v1beta1.WebhookClientConfig{
-			Service: &v1beta1.ServiceReference{
+		ClientConfig: admissionregistration.WebhookClientConfig{
+			Service: &admissionregistration.ServiceReference{
 				Namespace: namespace,
 				Name:      serviceName,
 				Path:      StrPtr(validationPath),
@@ -198,10 +198,10 @@ func (c *client) createAdmissionService(
 		FailurePolicy:  &Ignore,
 	}
 
-	validator := &v1beta1.ValidatingWebhookConfiguration{
+	validator := &admissionregistration.ValidatingWebhookConfiguration{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "validatingWebhookConfiguration",
-			APIVersion: "admissionregistration.k8s.io/v1beta1",
+			APIVersion: "admissionregistration.k8s.io/admissionregistration",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: validatorWebhook,
@@ -212,7 +212,7 @@ func (c *client) createAdmissionService(
 			},
 			OwnerReferences: []metav1.OwnerReference{ownerReference},
 		},
-		Webhooks: []v1beta1.ValidatingWebhook{webhookHandler},
+		Webhooks: []admissionregistration.ValidatingWebhook{webhookHandler},
 	}
 
 	_, err = c.kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().
@@ -282,7 +282,7 @@ func (c *client) createCertsSecret(
 // Openebs namespace.
 func GetValidatorWebhook(
 	validator string, kubeClient kubernetes.Interface,
-) (*v1beta1.ValidatingWebhookConfiguration, error) {
+) (*admissionregistration.ValidatingWebhookConfiguration, error) {
 
 	return kubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Get(validator, metav1.GetOptions{})
 }

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -19,6 +19,7 @@ package webhook
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"reflect"
@@ -237,14 +238,25 @@ func getDuplicateBlockDeviceList(cspc *cstor.CStorPoolCluster) []string {
 }
 
 func (poolValidator *PoolValidator) poolSpecValidation() (bool, string) {
-	if len(poolValidator.poolSpec.DataRaidGroups) == 0 {
-		return false, "at least one raid group should be present on pool spec"
-	}
 	// TODO : Add validation for pool config
 	// Pool config will require mutating webhooks also.
 	ok, msg := poolValidator.poolConfigValidation(poolValidator.poolSpec.PoolConfig)
 	if !ok {
 		return false, msg
+	}
+	if len(poolValidator.poolSpec.DataRaidGroups) == 0 {
+		return false, "at least one raid group should be present on dataRaidGroups"
+	}
+	if len(poolValidator.poolSpec.WriteCacheRaidGroups) == 0 {
+		return false, "at least one raid group should be present on writeCacheRaidGroups"
+	}
+	if poolValidator.poolSpec.PoolConfig.DataRaidGroupType == string(cstor.PoolStriped) &&
+		len(poolValidator.poolSpec.DataRaidGroups) != 1 {
+		return false, "stripe dataRaidGroups should have exactly one raidGroup"
+	}
+	if poolValidator.poolSpec.PoolConfig.WriteCacheGroupType == string(cstor.PoolStriped) &&
+		len(poolValidator.poolSpec.WriteCacheRaidGroups) != 1 {
+		return false, "stripe writeCacheRaidGroups should have exactly one raidGroup"
 	}
 	for _, raidGroup := range poolValidator.poolSpec.DataRaidGroups {
 		raidGroup := raidGroup // pin it
@@ -253,7 +265,51 @@ func (poolValidator *PoolValidator) poolSpecValidation() (bool, string) {
 			return false, msg
 		}
 	}
+	for _, raidGroup := range poolValidator.poolSpec.WriteCacheRaidGroups {
+		raidGroup := raidGroup // pin it
+		ok, msg := poolValidator.raidGroupValidation(&raidGroup, poolValidator.poolSpec.PoolConfig.WriteCacheGroupType)
+		if !ok {
+			return false, msg
+		}
+	}
+	return true, ""
+}
 
+type validateRaidBDCount func(int) (bool, string)
+
+func isStripedBDCountValid(count int) (bool, string) {
+	if count < 1 {
+		return false, fmt.Sprint("stripe raid group should have atleast one disk")
+	}
+	return true, ""
+}
+
+func isMirroredBDCountValid(count int) (bool, string) {
+	if count%2 != 0 {
+		return false, fmt.Sprint("mirror raid group should have disks in multiple of 2")
+	}
+	return true, ""
+}
+
+func isRaidzBDCountValid(count int) (bool, string) {
+	// the number of disk should be 2^n+1 where n >= 1
+	n := count - 1
+	x := math.Ceil(math.Log2(float64(n)))
+	y := math.Floor(math.Log2(float64(n)))
+	if x != y || x < 1 {
+		return false, fmt.Sprint("raidz raid group should have disks of the order 2^n+1, where n>0")
+	}
+	return true, ""
+}
+
+func isRaidz2BDCountValid(count int) (bool, string) {
+	// the number of disk should be 2^n+2 where n >= 2
+	n := count - 2
+	x := math.Ceil(math.Log2(float64(n)))
+	y := math.Floor(math.Log2(float64(n)))
+	if x != y || x < 2 {
+		return false, fmt.Sprint("raidz raid group should have disks of the order 2^n+2, where n>1")
+	}
 	return true, ""
 }
 
@@ -262,11 +318,17 @@ var (
 	// Value of the keys --
 	// 1. In case of striped this is the minimum number of disk required.
 	// 2. In all other cases this is the exact number of disks required.
-	SupportedPRaidType = map[cstor.PoolType]int{
-		cstor.PoolStriped:  1,
-		cstor.PoolMirrored: 2,
-		cstor.PoolRaidz:    3,
-		cstor.PoolRaidz2:   6,
+	SupportedPRaidType = map[cstor.PoolType]validateRaidBDCount{
+		cstor.PoolStriped:  isStripedBDCountValid,
+		cstor.PoolMirrored: isMirroredBDCountValid,
+		cstor.PoolRaidz:    isRaidzBDCountValid,
+		cstor.PoolRaidz2:   isRaidz2BDCountValid,
+	}
+	// SupportedCompression is a map holding the supported compressions
+	SupportedCompression = map[string]bool{
+		"":    true,
+		"off": true,
+		"lz":  true,
 	}
 )
 
@@ -276,7 +338,16 @@ func (poolValidator *PoolValidator) poolConfigValidation(
 		return false, fmt.Sprintf("missing dataRaidGroupType")
 	}
 	if _, ok := SupportedPRaidType[cstor.PoolType(poolConfig.DataRaidGroupType)]; !ok {
-		return false, fmt.Sprintf("unsupported raid type '%s' specified", poolConfig.DataRaidGroupType)
+		return false, fmt.Sprintf("unsupported dataRaidGroupType '%s' specified", poolConfig.DataRaidGroupType)
+	}
+	if poolConfig.WriteCacheGroupType == "" {
+		return false, fmt.Sprintf("missing writeCacheGroupType")
+	}
+	if _, ok := SupportedPRaidType[cstor.PoolType(poolConfig.WriteCacheGroupType)]; !ok {
+		return false, fmt.Sprintf("unsupported writeCacheGroupType '%s' specified", poolConfig.WriteCacheGroupType)
+	}
+	if _, ok := SupportedCompression[poolConfig.Compression]; !ok {
+		return false, fmt.Sprintf("unsupported compression '%s' specified", poolConfig.Compression)
 	}
 	return true, ""
 }
@@ -285,17 +356,11 @@ func (poolValidator *PoolValidator) raidGroupValidation(
 	raidGroup *cstor.RaidGroup, rgType string) (bool, string) {
 
 	if len(raidGroup.BlockDevices) == 0 {
-		return false, fmt.Sprintf("number of block devices honouring raid type should be specified")
+		return false, fmt.Sprintf("empty raid group: number of block devices honouring raid type should be specified")
 	}
 
-	if rgType != string(cstor.PoolStriped) {
-		if len(raidGroup.BlockDevices) != SupportedPRaidType[cstor.PoolType(rgType)] {
-			return false, fmt.Sprintf("number of block devices honouring raid type should be specified")
-		}
-	} else {
-		if len(raidGroup.BlockDevices) < SupportedPRaidType[cstor.PoolType(rgType)] {
-			return false, fmt.Sprintf("number of block devices honouring raid type should be specified")
-		}
+	if ok, msg := SupportedPRaidType[cstor.PoolType(rgType)](len(raidGroup.BlockDevices)); !ok {
+		return false, msg
 	}
 
 	for _, bd := range raidGroup.BlockDevices {


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR
-  adds validation for new schema changes in CSPC. 
-  reverts the API version of `ValidatingWebhookConfig` to v1beta1 as the `sideEffectClass` `NoneOnDryRun` does not seem to work in this case and v1 does not support `Unknown` class. Will look into it until then using v1beta1.

TODO:
 - validation for expansion
 - validation for capacity

will take these in separate PRs.