### PR TITLE
feat(roThresholdLimit): add ROThresholdLimit support in pool manager

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -401,6 +401,10 @@ github.com/openebs/api v0.0.0-20200304155919-9ac1d4814a3f h1:EY8TgLsbAGhq4qhnoDb
 github.com/openebs/api v0.0.0-20200304155919-9ac1d4814a3f/go.mod h1:Mj6izkLZT0jNKLs9u1CnbgNoP9BEgY/mgVI7Mc3/Hwc=
 github.com/openebs/api v0.0.0-20200311104100-f6a5bd72fae3 h1:30wuJe3AEcwYsq3w6t0k0SHhjreXN2EnqUvuP6Lwa0I=
 github.com/openebs/api v0.0.0-20200311104100-f6a5bd72fae3/go.mod h1:Mj6izkLZT0jNKLs9u1CnbgNoP9BEgY/mgVI7Mc3/Hwc=
+github.com/openebs/api v0.0.0-20200316115502-9a4c0b1367c3 h1:/R2zYRJ0N9knT71TGXZHRJQIwj1RS/JWlQD8SB7vdnI=
+github.com/openebs/api v0.0.0-20200316115502-9a4c0b1367c3/go.mod h1:Mj6izkLZT0jNKLs9u1CnbgNoP9BEgY/mgVI7Mc3/Hwc=
+github.com/openebs/api v0.0.0-20200319152258-4190ca81ae69 h1:KRLrzRLf7oBnVSMDRCaSt0i+XwW7ucQ0sziey1CZAXw=
+github.com/openebs/api v0.0.0-20200319152258-4190ca81ae69/go.mod h1:Mj6izkLZT0jNKLs9u1CnbgNoP9BEgY/mgVI7Mc3/Hwc=
 github.com/openebs/api v0.0.0-20200319173602-da787ed9fcbf h1:QGAdLxow+WVfxTOxeli3RdzWp9SPRJl1GzNS/M8mOow=
 github.com/openebs/api v0.0.0-20200319173602-da787ed9fcbf/go.mod h1:Mj6izkLZT0jNKLs9u1CnbgNoP9BEgY/mgVI7Mc3/Hwc=
 github.com/openebs/maya v0.0.0-20200226142318-6daf5f0486e8 h1:ud86nr1TRU9fB3IeBzymBqYjaha/GjgjHCTeFTKeT8A=

--- a/pkg/controllers/cspi-controller/handler.go
+++ b/pkg/controllers/cspi-controller/handler.go
@@ -239,10 +239,10 @@ func (c *CStorPoolInstanceController) updateStatus(cspi *cstor.CStorPoolInstance
 //       cspiStatus information from zfs/zpool
 func (c *CStorPoolInstanceController) updateROMode(
 	cspiStatus *cstor.CStorPoolInstanceStatus, cspi cstor.CStorPoolInstance) {
-	if cspi.Spec.PoolConfig.ROThresholdLimit == nil {
-		return
+	roThresholdLimit := 85
+	if cspi.Spec.PoolConfig.ROThresholdLimit != nil {
+		roThresholdLimit = *cspi.Spec.PoolConfig.ROThresholdLimit
 	}
-	roThresholdLimit := *cspi.Spec.PoolConfig.ROThresholdLimit
 	totalInBytes := cspiStatus.Capacity.Total.Value()
 	usedInBytes := cspiStatus.Capacity.Used.Value()
 	pool := zpool.PoolName()

--- a/pkg/cspc/algorithm/build_csp.go
+++ b/pkg/cspc/algorithm/build_csp.go
@@ -34,6 +34,7 @@ const (
 // GetCSPSpec returns a CSPI spec that should be created and claims all the
 // block device present in the CSPI spec
 func (ac *Config) GetCSPISpec() (*cstor.CStorPoolInstance, error) {
+	defaultROThresholdLimit := 85
 	poolSpec, nodeName, err := ac.SelectNode()
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to select a node")
@@ -58,8 +59,8 @@ func (ac *Config) GetCSPISpec() (*cstor.CStorPoolInstance, error) {
 		poolSpec.PoolConfig.PriorityClassName = ac.CSPC.Spec.DefaultPriorityClassName
 	}
 
-	if poolSpec.PoolConfig.ROThresholdLimit == 0 {
-		poolSpec.PoolConfig.ROThresholdLimit = 85
+	if poolSpec.PoolConfig.ROThresholdLimit == nil {
+		poolSpec.PoolConfig.ROThresholdLimit = &defaultROThresholdLimit
 	}
 
 	cspiLabels := ac.buildLabelsForCSPI(nodeName)

--- a/pkg/cspc/algorithm/build_csp.go
+++ b/pkg/cspc/algorithm/build_csp.go
@@ -58,6 +58,10 @@ func (ac *Config) GetCSPISpec() (*cstor.CStorPoolInstance, error) {
 		poolSpec.PoolConfig.PriorityClassName = ac.CSPC.Spec.DefaultPriorityClassName
 	}
 
+	if poolSpec.PoolConfig.ROThresholdLimit == 0 {
+		poolSpec.PoolConfig.ROThresholdLimit = 85
+	}
+
 	cspiLabels := ac.buildLabelsForCSPI(nodeName)
 	cspiObj := cstor.NewCStorPoolInstance().
 		WithName(ac.CSPC.Name + "-" + rand.String(4)).

--- a/pkg/pool/operations/status.go
+++ b/pkg/pool/operations/status.go
@@ -41,6 +41,7 @@ func GetPropertyValue(poolName, property string) (string, error) {
 }
 
 // GetListOfPropertyValues will return value list for given property list
+// NOTE: It will return the property values in the same order as property list
 func GetListOfPropertyValues(poolName string, propertyList []string) ([]string, error) {
 	ret, err := zfs.NewPoolGetProperty().
 		WithScriptedMode(true).
@@ -71,6 +72,11 @@ func GetCSPICapacity(poolName string) (cstor.CStorPoolInstanceCapacity, error) {
 			err,
 		)
 	}
+	// Since it was quarried in free, allocated and size output also
+	// will be in same order.
+	// valueList[0] contains value of free capacity in cStor pool
+	// valueList[1] contains value of allocated capacity in cStor pool
+	// valueList[2] contains total capacity of cStor pool
 	freeSizeInBinarySI := GetCapacityInBinarySi(valueList[0])
 	allocatedSizeInBinarySI := GetCapacityInBinarySi(valueList[1])
 	totalSizeInBinarySI := GetCapacityInBinarySi(valueList[2])

--- a/pkg/zcmd/zpool/get/builder.go
+++ b/pkg/zcmd/zpool/get/builder.go
@@ -76,6 +76,12 @@ func (p *PoolGProperty) WithProperty(key string) *PoolGProperty {
 	return p
 }
 
+// WithPropertyList method fills the PropList field of PoolGProperty object.
+func (p *PoolGProperty) WithPropertyList(keys []string) *PoolGProperty {
+	p.PropList = append(p.PropList, keys...)
+	return p
+}
+
 // WithScriptedMode method update the IsScriptedMode field of PoolGProperty object.
 func (p *PoolGProperty) WithScriptedMode(IsScriptedMode bool) *PoolGProperty {
 	p.IsScriptedMode = IsScriptedMode


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR adds support for ROThresholdLimit in the pool manager.

Note:
1. If `roThresholdLimit` is set to `0` or `100`:
    -  Writes on the pool will be allowed until it runs out of space.

Sample CSPI spec and status when pool in RW state
```sh
    poolConfig:
      ...
      ...
      roThresholdLimit: 12
  status:
    Conditions: null
    capacity:
      free: 9470M
      total: 9940M
      used: 476M
    phase: ""
    readOnly: false
```
Sample CSPI spec and status when pool is in RO mode
```sh
    poolConfig:
      ...
      ...
      roThresholdLimit: 2
  status:
    Conditions: null
    capacity:
      free: 9470M
      total: 9940M
      used: 476M
    phase: ""
    readOnly: true
```
Events Generation:

```sh
I0312 18:00:30.985242   19525 event.go:281] Event(v1.ObjectReference{Kind:"CStorPoolInstance", Namespace:"openebs", Name:"cspi-stripe", UID:"be8e517b-508d-4044-93bd-67e668593d4d", APIVersion:"cstor.openebs.io/v1", ResourceVersion:"1923", FieldPath:""}): type: 'Warning' reason: 'PoolReadOnlyThreshold' Pool storage limit reached to thresholdLimit. Pool expansion is required to make it's volume replicas RW
...
...
I0312 18:31:55.654584   26872 event.go:281] Event(v1.ObjectReference{Kind:"CStorPoolInstance", Namespace:"openebs", Name:"cspi-stripe", UID:"be8e517b-508d-4044-93bd-67e668593d4d", APIVersion:"cstor.openebs.io/v1", ResourceVersion:"3172", FieldPath:""}): type: 'Normal' reason: 'PoolReadOnlyThreshold' Pool roThresholdLimit or pool got expanded due to that pool readOnly mode is unset
```
TODO:
Fix travis after PR in api got merged.