### PR TITLE
fix(yaml): update poolConfig fields in examples

### DIFF
--- a/examples/crds/cspicrd.yaml
+++ b/examples/crds/cspicrd.yaml
@@ -21,4 +21,28 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
       - cspi
+  additionalPrinterColumns:
+    - JSONPath: .spec.hostName
+      name: HostName
+      description: Host name where cstorpool instances scheduled
+      type: string
+    - JSONPath: .status.capacity.used
+      name: Allocated
+      description: The amount of storage space within the pool that has been physically allocated
+      type: string
+    - JSONPath: .status.capacity.free
+      name: Free
+      description: The amount of free space available in the pool
+      type: string
+    - JSONPath: .status.capacity.total
+      name: Capacity
+      description: Total size of the storage pool
+      type: string
+    - JSONPath: .status.phase
+      name: Status
+      description: Identifies the current health of the pool
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
 ---

--- a/examples/cspc/cspc-single.yaml
+++ b/examples/cspc/cspc-single.yaml
@@ -11,4 +11,4 @@ spec:
       - blockDevices:
           - blockDeviceName: "sparse-1e3a8da94af49e16d937d867777699b0"
       poolConfig:
-        defaultRaidGroupType: "stripe"
+        dataRaidGroupType: "stripe"


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR 
- corrects the fields in poolConfig of example.
- adds `additionalPrinterColumns` for `CSPI` crd for proper status via kubectl get.