### PR TITLE
chore(cvc): refactor volume and pool provisioning including updated image names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ volume-manager-image:
 	@echo "----------------------------"
 	@PNAME=${VOLUME_MANAGER} CTLNAME=${VOLUME_MANAGER} sh -c "'$(PWD)/build/build.sh'"
 	@cp bin/${VOLUME_MANAGER}/${VOLUME_MANAGER} build/volume-manager/
-	@cd build/${VOLUME_MANAGER} && sudo docker build -t ${HUB_USER}/${VOLUME_MANAGER}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd build/${VOLUME_MANAGER} && sudo docker build -t ${HUB_USER}/cstor-${VOLUME_MANAGER}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm build/${VOLUME_MANAGER}/${VOLUME_MANAGER}
 
 .PHONY: cspc-operator-image
@@ -117,7 +117,7 @@ pool-manager-image:
 	@echo "----------------------------"
 	@PNAME=${POOL_MANAGER} CTLNAME=${POOL_MANAGER} sh -c "'$(PWD)/build/build.sh'"
 	@cp bin/${POOL_MANAGER}/${POOL_MANAGER} build/pool-manager/
-	@cd build/${POOL_MANAGER} && sudo docker build -t ${HUB_USER}/${POOL_MANAGER}:${IMAGE_TAG} --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE} --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
+	@cd build/${POOL_MANAGER} && sudo docker build -t ${HUB_USER}/cstor-${POOL_MANAGER}:${IMAGE_TAG} --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE} --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
 	@rm build/${POOL_MANAGER}/${POOL_MANAGER}
 
 .PHONY: cstor-webhook-image

--- a/pkg/controllers/cstorvolumeclaim/deployment.go
+++ b/pkg/controllers/cstorvolumeclaim/deployment.go
@@ -229,6 +229,14 @@ func getDeployTemplateEnvs(cstorid string) []corev1.EnvVar {
 				},
 			},
 		},
+		corev1.EnvVar{
+			Name: "OPENEBS_NAMESPACE",
+			ValueFrom: &corev1.EnvVarSource{
+				FieldRef: &corev1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
 	}
 }
 
@@ -260,7 +268,7 @@ func getVolumeMonitorImage() string {
 func getVolumeMgmtImage() string {
 	image, present := os.LookupEnv("OPENEBS_IO_CSTOR_VOLUME_MGMT_IMAGE")
 	if !present {
-		image = "openebs/cstor-volume-mgmt:ci"
+		image = "openebs/cstor-volume-manager:ci"
 	}
 	return image
 }
@@ -385,12 +393,7 @@ func (c *CVCController) getOrCreateCStorTargetDeployment(
 			).
 			Build()
 
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to build deployment object")
-		}
-
 		deployObj, err = c.kubeclientset.AppsV1().Deployments(openebsNamespace).Create(deployObj)
-
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to create deployment object")
 		}

--- a/pkg/controllers/cstorvolumeclaim/volume_operations.go
+++ b/pkg/controllers/cstorvolumeclaim/volume_operations.go
@@ -250,13 +250,6 @@ func (c *CVCController) getOrCreateTargetService(
 		WithSelectorsNew(getTargetServiceSelectors(claim)).
 		WithPorts(cvPorts).
 		Build()
-		//	if err != nil {
-		//		return nil, errors.Wrapf(
-		//			err,
-		//			"failed to build target service {%v}",
-		//			svcObj,
-		//		)
-		//	}
 
 	svcObj, err = c.kubeclientset.CoreV1().Services(openebsNamespace).Create(svcObj)
 	return svcObj, err
@@ -315,13 +308,6 @@ func (c *CVCController) getOrCreateCStorVolumeResource(
 			WithNewVersion(version.GetVersion()).
 			WithDependentsUpgraded()
 
-		if err != nil {
-			return nil, errors.Wrapf(
-				err,
-				"failed to build cstorvolume {%v}",
-				claim.Name,
-			)
-		}
 		return c.clientset.CstorV1().CStorVolumes(openebsNamespace).Create(cvObj)
 	}
 	return cvObj, err
@@ -454,15 +440,7 @@ func (c *CVCController) createCVR(
 			WithDependentsUpgraded().
 			WithStatusPhase(rInfo.phase)
 
-		//	if err != nil {
-		//	return nil, errors.Wrapf(
-		//	err,
-		//	"failed to build cstorvolumereplica {%v}",
-		//	cvrObj.Name,
-		//)
-		//}
-		cvrObj, err = c.clientset.CstorV1().CStorVolumeReplicas(openebsNamespace).
-			Create(cvrObj)
+		cvrObj, err = c.clientset.CstorV1().CStorVolumeReplicas(openebsNamespace).Create(cvrObj)
 		if err != nil {
 			return nil, errors.Wrapf(
 				err,

--- a/pkg/cspc/algorithm/build_deploy.go
+++ b/pkg/cspc/algorithm/build_deploy.go
@@ -17,6 +17,8 @@ limitations under the License.
 package algorithm
 
 import (
+	"os"
+
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	"github.com/openebs/api/pkg/apis/types"
 	deployapi "github.com/openebs/api/pkg/kubernetes/apps"
@@ -26,7 +28,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
 )
 
 // OpenEBSServiceAccount name of the openebs service accout with required
@@ -77,7 +78,7 @@ var (
 )
 
 // GetPoolDeploySpec returns the pool deployment spec.
-func (c *Config) GetPoolDeploySpec(cspi *cstor.CStorPoolInstance) (*appsv1.Deployment) {
+func (c *Config) GetPoolDeploySpec(cspi *cstor.CStorPoolInstance) *appsv1.Deployment {
 	deployObj := deployapi.NewDeployment().
 		WithName(cspi.Name).
 		WithNamespace(cspi.Namespace).
@@ -99,7 +100,7 @@ func (c *Config) GetPoolDeploySpec(cspi *cstor.CStorPoolInstance) (*appsv1.Deplo
 					coreapi.NewContainer().
 						WithImage(getPoolMgmtImage()).
 						WithName(PoolMgmtContainerName).
-						WithImagePullPolicy(corev1.PullAlways).
+						WithImagePullPolicy(corev1.PullIfNotPresent).
 						WithPrivilegedSecurityContext(&privileged).
 						WithEnvsNew(getPoolMgmtEnv(cspi)).
 						WithEnvs(getPoolUIDAsEnv(c.CSPC)).
@@ -109,7 +110,7 @@ func (c *Config) GetPoolDeploySpec(cspi *cstor.CStorPoolInstance) (*appsv1.Deplo
 						WithImage(getPoolImage()).
 						WithName(PoolContainerName).
 						WithResources(getResourceRequirementForCStorPool(cspi)).
-						WithImagePullPolicy(corev1.PullAlways).
+						WithImagePullPolicy(corev1.PullIfNotPresent).
 						WithPrivilegedSecurityContext(&privileged).
 						WithPortsNew(getContainerPort(12000, 3232, 3233)).
 						WithLivenessProbe(getPoolLivenessProbe()).
@@ -121,7 +122,7 @@ func (c *Config) GetPoolDeploySpec(cspi *cstor.CStorPoolInstance) (*appsv1.Deplo
 						WithImage(getMayaExporterImage()).
 						WithName(PoolExporterContainerName).
 						// TODO: add default values for resources
-						WithImagePullPolicy(corev1.PullAlways).
+						WithImagePullPolicy(corev1.PullIfNotPresent).
 						WithPrivilegedSecurityContext(&privileged).
 						WithPortsNew(getContainerPort(9500)).
 						WithCommandNew([]string{"maya-exporter"}).

--- a/pkg/cspc/algorithm/build_deploy.go
+++ b/pkg/cspc/algorithm/build_deploy.go
@@ -228,7 +228,7 @@ func getDeployMatchLabels() map[string]string {
 func getPoolMgmtImage() string {
 	image, present := os.LookupEnv("OPENEBS_IO_CSPI_MGMT_IMAGE")
 	if !present {
-		image = "quay.io/openebs/pool-manager:ci"
+		image = "quay.io/openebs/cstor-pool-manager:ci"
 	}
 	return image
 }


### PR DESCRIPTION
- fix volume provisioning due to stale error checks
- Rename `pool-manager` image to `cstor-pool-manager`
- rename `volume-manager` image to `cstor-volume-manager`
- Use `IfNotPresent` instead of `Always` pull container images in pool deployment.

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>