### PR TITLE
fix(cspi, status): fix CSPI status to represent capacity and Phase of pool

### DIFF
--- a/pkg/controllers/cspi-controller/handler.go
+++ b/pkg/controllers/cspi-controller/handler.go
@@ -193,15 +193,14 @@ func (c *CStorPoolInstanceController) updateStatus(cspi *cstor.CStorPoolInstance
 	// ToDo: Use the status from the cspi object that is passed in arg else other fields
 	// might get lost.
 	var status cstor.CStorPoolInstanceStatus
-	var err error
 	pool := zpool.PoolName()
 	propertyList := []string{"health", "io.openebs:readonly"}
 
 	// Since we quarried in following order health and io.openebs:readonly output also
 	// will be in same order
-	valueList, er := zpool.GetListOfPropertyValues(pool, propertyList)
-	if er != nil || len(valueList) != len(propertyList) {
-		return errors.Wrapf(err, "Failed to fetch %v output: %v", propertyList, valueList)
+	valueList, err := zpool.GetListOfPropertyValues(pool, propertyList)
+	if err != nil {
+		return errors.Errorf("Failed to fetch %v output: %v error: %v", propertyList, valueList, err)
 	} else {
 		// valueList[0] will hold the value of health of cStor pool
 		// valueList[1] will hold the value of io.openebs:readonly of cStor pool
@@ -218,7 +217,6 @@ func (c *CStorPoolInstanceController) updateStatus(cspi *cstor.CStorPoolInstance
 	c.updateROMode(&status, *cspi)
 
 	if IsStatusChange(cspi.Status, status) {
-		klog.Infof("Status %v", status)
 		cspi.Status = status
 		_, err = zpool.OpenEBSClient.
 			CstorV1().

--- a/pkg/pool/operations/modify.go
+++ b/pkg/pool/operations/modify.go
@@ -79,7 +79,7 @@ func (oc *OperationsConfig) Update(cspi *cstor.CStorPoolInstance) (*cstor.CStorP
 					bdev.BlockDeviceName)
 				if er != nil {
 					// This case is not possible
-					err = ErrorWrapf(er,
+					err = ErrorWrapf(err,
 						"Failed to get claim of blockdevice {%s}.. %s",
 						bdev.BlockDeviceName,
 						er.Error())

--- a/pkg/pool/operations/status.go
+++ b/pkg/pool/operations/status.go
@@ -29,7 +29,6 @@ import (
 func GetPropertyValue(poolName, property string) (string, error) {
 	ret, err := zfs.NewPoolGetProperty().
 		WithScriptedMode(true).
-		WithParsableMode(true).
 		WithField("value").
 		WithProperty(property).
 		WithPool(poolName).
@@ -46,7 +45,6 @@ func GetPropertyValue(poolName, property string) (string, error) {
 func GetListOfPropertyValues(poolName string, propertyList []string) ([]string, error) {
 	ret, err := zfs.NewPoolGetProperty().
 		WithScriptedMode(true).
-		WithParsableMode(true).
 		WithField("value").
 		WithPropertyList(propertyList).
 		WithPool(poolName).

--- a/pkg/pool/operations/status.go
+++ b/pkg/pool/operations/status.go
@@ -29,6 +29,7 @@ import (
 func GetPropertyValue(poolName, property string) (string, error) {
 	ret, err := zfs.NewPoolGetProperty().
 		WithScriptedMode(true).
+		WithParsableMode(true).
 		WithField("value").
 		WithProperty(property).
 		WithPool(poolName).
@@ -45,6 +46,7 @@ func GetPropertyValue(poolName, property string) (string, error) {
 func GetListOfPropertyValues(poolName string, propertyList []string) ([]string, error) {
 	ret, err := zfs.NewPoolGetProperty().
 		WithScriptedMode(true).
+		WithParsableMode(true).
 		WithField("value").
 		WithPropertyList(propertyList).
 		WithPool(poolName).
@@ -52,7 +54,10 @@ func GetListOfPropertyValues(poolName string, propertyList []string) ([]string, 
 	if err != nil {
 		return []string{}, err
 	}
-	outStr := strings.Split(strings.TrimSpace(string(ret)), "\n")
+	// NOTE: Don't trim space there might be possibility for some
+	// properties values might be empty. If we trim the space we
+	// will lost the property values
+	outStr := strings.Split(string(ret), "\n")
 	return outStr, nil
 
 }
@@ -63,7 +68,7 @@ func GetCSPICapacity(poolName string) (cstor.CStorPoolInstanceCapacity, error) {
 	propertyList := []string{"free", "allocated", "size"}
 	cspiCapacity := cstor.CStorPoolInstanceCapacity{}
 	valueList, err := GetListOfPropertyValues(poolName, propertyList)
-	if err != nil || len(valueList) != len(propertyList) {
+	if err != nil {
 		return cspiCapacity, errors.Errorf(
 			"failed to get pool %v properties for pool %s cmd out: %v error: %v",
 			propertyList,


### PR DESCRIPTION
This commit fixes the error handling bugs and ZPOOL
handling bugs.
```sh
kubectl get cspi -n openebs
NAME          HOSTNAME    ALLOCATED   FREE    CAPACITY   STATUS   AGE
cspi-stripe   127.0.0.1   69500       9940M   9940M      ONLINE   9m10s
```

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>