### PR TITLE
feat(cspi): add capability to set compression on cstor pool

### DIFF
--- a/pkg/controllers/cspi-controller/handler.go
+++ b/pkg/controllers/cspi-controller/handler.go
@@ -89,13 +89,20 @@ func (c *CStorPoolInstanceController) reconcile(key string) error {
 		}
 		zpool.CheckImportedPoolVolume()
 		common.SyncResources.Mux.Unlock()
-		err = c.update(cspi)
+		cspiGot, err := c.update(cspi)
 		if err != nil {
-			c.recorder.Event(cspi,
+			c.recorder.Event(cspiGot,
 				corev1.EventTypeWarning,
 				string(common.FailedSynced),
 				err.Error())
 		}
+
+		// If everything is alright here -- sync the cspi
+		// Note: Even if update fails, cspiGot will not be nil.
+		// In case of failed update, passed cspi to update functions
+		// is returned.
+		c.sync(cspiGot)
+
 		return nil
 	}
 
@@ -119,7 +126,7 @@ func (c *CStorPoolInstanceController) reconcile(key string) error {
 			string(common.SuccessCreated),
 			fmt.Sprintf("Pool created successfully"))
 
-		err = c.update(cspi)
+		_, err := c.update(cspi)
 		if err != nil {
 			c.recorder.Event(cspi,
 				corev1.EventTypeWarning,
@@ -177,19 +184,19 @@ updatestatus:
 	return err
 }
 
-func (c *CStorPoolInstanceController) update(cspi *cstor.CStorPoolInstance) error {
+func (c *CStorPoolInstanceController) update(cspi *cstor.CStorPoolInstance) (*cstor.CStorPoolInstance, error) {
 	oc := zpool.NewOperationsConfig().
 		WithKubeClientSet(c.kubeclientset).
 		WithOpenEBSClient(c.clientset).
 		WithRecorder(c.recorder)
 	cspi, err := oc.Update(cspi)
 	if err != nil {
-		return errors.Errorf("Failed to update pool due to %s", err.Error())
+		return nil, errors.Errorf("Failed to update pool due to %s", err.Error())
 	}
 	return c.updateStatus(cspi)
 }
 
-func (c *CStorPoolInstanceController) updateStatus(cspi *cstor.CStorPoolInstance) error {
+func (c *CStorPoolInstanceController) updateStatus(cspi *cstor.CStorPoolInstance) (*cstor.CStorPoolInstance, error) {
 	// ToDo: Use the status from the cspi object that is passed in arg else other fields
 	// might get lost.
 	var status cstor.CStorPoolInstanceStatus
@@ -200,7 +207,7 @@ func (c *CStorPoolInstanceController) updateStatus(cspi *cstor.CStorPoolInstance
 	// will be in same order
 	valueList, err := zpool.GetListOfPropertyValues(pool, propertyList)
 	if err != nil {
-		return errors.Errorf("Failed to fetch %v output: %v error: %v", propertyList, valueList, err)
+		return nil, errors.Errorf("Failed to fetch %v output: %v error: %v", propertyList, valueList, err)
 	} else {
 		// valueList[0] will hold the value of health of cStor pool
 		// valueList[1] will hold the value of io.openebs:readonly of cStor pool
@@ -212,21 +219,23 @@ func (c *CStorPoolInstanceController) updateStatus(cspi *cstor.CStorPoolInstance
 
 	status.Capacity, err = zpool.GetCSPICapacity(pool)
 	if err != nil {
-		return errors.Errorf("Failed to sync due to %s", err.Error())
+		return nil, errors.Errorf("Failed to sync due to %s", err.Error())
 	}
 	c.updateROMode(&status, *cspi)
 
 	if IsStatusChange(cspi.Status, status) {
 		cspi.Status = status
-		_, err = zpool.OpenEBSClient.
+		cspiGot, err := zpool.OpenEBSClient.
 			CstorV1().
 			CStorPoolInstances(cspi.Namespace).
 			Update(cspi)
 		if err != nil {
-			return errors.Errorf("Failed to updateStatus due to '%s'", err.Error())
+			return nil, errors.Errorf("Failed to updateStatus due to '%s'", err.Error())
 		}
+		return cspiGot, nil
 	}
-	return nil
+
+	return cspi, nil
 }
 
 // updateROMode sets/unsets the pool readonly mode property. It does the following changes
@@ -345,4 +354,17 @@ func (c *CStorPoolInstanceController) addPoolProtectionFinalizer(
 		cspi.Name,
 		string(cspi.GetUID()))
 	return newCSPI, nil
+}
+
+func (c *CStorPoolInstanceController) sync(cspi *cstor.CStorPoolInstance) {
+	// Right now the only sync activity is compression
+	compressionType := cspi.Spec.PoolConfig.Compression
+	poolName := zpool.PoolName()
+	err := zpool.SetCompression(poolName, compressionType)
+	if err != nil {
+		c.recorder.Event(cspi,
+			corev1.EventTypeWarning,
+			"Pool "+string("FailedToSetCompression"),
+			fmt.Sprintf("Failed to set compression %s to the pool %s : %s", compressionType, poolName, err.Error()))
+	}
 }

--- a/pkg/controllers/cspi-controller/handler.go
+++ b/pkg/controllers/cspi-controller/handler.go
@@ -230,7 +230,7 @@ func (c *CStorPoolInstanceController) updateStatus(cspi *cstor.CStorPoolInstance
 			CStorPoolInstances(cspi.Namespace).
 			Update(cspi)
 		if err != nil {
-			return nil, errors.Errorf("Failed to updateStatus due to '%s'", err.Error())
+			return cspi, errors.Errorf("Failed to updateStatus due to '%s'", err.Error())
 		}
 		return cspiGot, nil
 	}

--- a/pkg/pool/operations/create.go
+++ b/pkg/pool/operations/create.go
@@ -94,10 +94,15 @@ func (oc *OperationsConfig) createPool(cspi *cstor.CStorPoolInstance, r cstor.Ra
 		vdevlist = append(vdevlist, v[0])
 	}
 
+	compressionType := cspi.Spec.PoolConfig.Compression
+	if compressionType == "" {
+		compressionType = "off"
+	}
+
 	ret, err := zfs.NewPoolCreate().
 		WithType(ptype).
 		WithProperty("cachefile", types.CStorPoolBasePath+types.CacheFileName).
-		WithProperty("compression", cspi.Spec.PoolConfig.Compression).
+		WithProperty("compression", compressionType).
 		WithPool(PoolName()).
 		WithVdevList(vdevlist).
 		Execute()

--- a/pkg/pool/operations/create.go
+++ b/pkg/pool/operations/create.go
@@ -96,7 +96,7 @@ func (oc *OperationsConfig) createPool(cspi *cstor.CStorPoolInstance, r cstor.Ra
 
 	compressionType := cspi.Spec.PoolConfig.Compression
 	if compressionType == "" {
-		compressionType = "off"
+		compressionType = "lz4"
 	}
 
 	ret, err := zfs.NewPoolCreate().

--- a/pkg/pool/operations/create.go
+++ b/pkg/pool/operations/create.go
@@ -17,10 +17,12 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"fmt"
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	"github.com/openebs/api/pkg/apis/types"
 	zfs "github.com/openebs/cstor-operators/pkg/zcmd"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 )
 
@@ -103,5 +105,16 @@ func (oc *OperationsConfig) createPool(cspi *cstor.CStorPoolInstance, r cstor.Ra
 	if err != nil {
 		return errors.Errorf("Failed to create pool.. %s .. %s", string(ret), err.Error())
 	}
+
+	// Set compression at the pool level
+	compressionType := cspi.Spec.PoolConfig.Compression
+	err = SetCompression(PoolName(), compressionType)
+	if err != nil {
+		oc.recorder.Event(cspi,
+			corev1.EventTypeWarning,
+			"Pool "+string("FailedToSetCompression"),
+			fmt.Sprintf("Failed to set compression %s to the pool %s : %s", compressionType, PoolName(), err.Error()))
+	}
+
 	return nil
 }

--- a/pkg/pool/operations/create.go
+++ b/pkg/pool/operations/create.go
@@ -17,12 +17,10 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"fmt"
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	"github.com/openebs/api/pkg/apis/types"
 	zfs "github.com/openebs/cstor-operators/pkg/zcmd"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 )
 
@@ -99,21 +97,12 @@ func (oc *OperationsConfig) createPool(cspi *cstor.CStorPoolInstance, r cstor.Ra
 	ret, err := zfs.NewPoolCreate().
 		WithType(ptype).
 		WithProperty("cachefile", types.CStorPoolBasePath+types.CacheFileName).
+		WithProperty("compression", cspi.Spec.PoolConfig.Compression).
 		WithPool(PoolName()).
 		WithVdevList(vdevlist).
 		Execute()
 	if err != nil {
 		return errors.Errorf("Failed to create pool.. %s .. %s", string(ret), err.Error())
-	}
-
-	// Set compression at the pool level
-	compressionType := cspi.Spec.PoolConfig.Compression
-	err = SetCompression(PoolName(), compressionType)
-	if err != nil {
-		oc.recorder.Event(cspi,
-			corev1.EventTypeWarning,
-			"Pool "+string("FailedToSetCompression"),
-			fmt.Sprintf("Failed to set compression %s to the pool %s : %s", compressionType, PoolName(), err.Error()))
 	}
 
 	return nil

--- a/pkg/pool/operations/pool_utils.go
+++ b/pkg/pool/operations/pool_utils.go
@@ -318,7 +318,7 @@ func (oc *OperationsConfig) cleanUpReplacementMarks(oldObj, newObj *openebsapis.
 func SetCompression(poolName string, compressionType string) error {
 	// If compression type is empty -- it means disable compression on the pool
 	if compressionType == "" {
-		compressionType = "off"
+		compressionType = "lz4"
 	}
 
 	// Get the compression value that exists in the pool

--- a/pkg/pool/operations/pool_utils.go
+++ b/pkg/pool/operations/pool_utils.go
@@ -321,6 +321,18 @@ func SetCompression(poolName string, compressionType string) error {
 		compressionType = "off"
 	}
 
+	// Get the compression value that exists in the pool
+	existingCompressionType, err := GetPropertyValue(poolName, "compression")
+	if err != nil {
+		return errors.Errorf("Failed to get compression type:err:%s", err.Error())
+	}
+
+	// If there is no change in the compression algorithm -- simply return.
+	if compressionType == existingCompressionType {
+		return nil
+	}
+
+	// If the requested compression algorithm is supported -- enable that.
 	if SupportedCompressionTypes[compressionType] {
 		ret, err := zfs.NewPoolSetProperty().
 			WithProperty("compression", compressionType).
@@ -334,5 +346,6 @@ func SetCompression(poolName string, compressionType string) error {
 		return nil
 	}
 
+	// If we are here, the requested compression algorithm is not supported.
 	return errors.Errorf("compression type %s not supported", compressionType)
 }


### PR DESCRIPTION
This commit adds capability to set compression on the cstor pool. The
Compression can be set via cspc and value must be one of 'on | off | lzjb |
gzip | gzip-[1-9] | zle | lz4'.

Note: lz4 is the defualt compression algorithm that is used if the compression field is left unspecified on the cspc.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>