### PR TITLE
fix(cspi): pool create with compression as filesystem property

### DIFF
--- a/pkg/pool/operations/create.go
+++ b/pkg/pool/operations/create.go
@@ -102,7 +102,7 @@ func (oc *OperationsConfig) createPool(cspi *cstor.CStorPoolInstance, r cstor.Ra
 	ret, err := zfs.NewPoolCreate().
 		WithType(ptype).
 		WithProperty("cachefile", types.CStorPoolBasePath+types.CacheFileName).
-		WithProperty("compression", compressionType).
+		WithFSProperty("compression", compressionType).
 		WithPool(PoolName()).
 		WithVdevList(vdevlist).
 		Execute()

--- a/pkg/zcmd/zpool/create/builder.go
+++ b/pkg/zcmd/zpool/create/builder.go
@@ -36,7 +36,8 @@ const (
 type PoolCreate struct {
 	// property list
 	Property []string
-
+	// file system property list
+	FSProperty []string
 	// pool name
 	Pool string
 
@@ -74,6 +75,14 @@ func (p *PoolCreate) WithCheck(check ...PredicateFunc) *PoolCreate {
 func (p *PoolCreate) WithProperty(key, value string) *PoolCreate {
 	if value != "" {
 		p.Property = append(p.Property, fmt.Sprintf("%s=%s", key, value))
+	}
+	return p
+}
+
+// WithFSProperty method fills the file system Property field of PoolCreate object.
+func (p *PoolCreate) WithFSProperty(key, value string) *PoolCreate {
+	if value != "" {
+		p.FSProperty = append(p.FSProperty, fmt.Sprintf("%s=%s", key, value))
 	}
 	return p
 }
@@ -149,6 +158,12 @@ func (p *PoolCreate) Build() (*PoolCreate, error) {
 	if IsPropertySet()(p) {
 		for _, v := range p.Property {
 			p.appendCommand(&c, fmt.Sprintf(" -o %s ", v))
+		}
+	}
+
+	if IsFSPropertySet()(p) {
+		for _, v := range p.FSProperty {
+			p.appendCommand(&c, fmt.Sprintf(" -O %s ", v))
 		}
 	}
 

--- a/pkg/zcmd/zpool/create/predicate.go
+++ b/pkg/zcmd/zpool/create/predicate.go
@@ -26,6 +26,14 @@ func IsPropertySet() PredicateFunc {
 	}
 }
 
+// IsFSPropertySet method check if the file system Property field of PoolCreate
+// object is set.
+func IsFSPropertySet() PredicateFunc {
+	return func(p *PoolCreate) bool {
+		return len(p.FSProperty) != 0
+	}
+}
+
 // IsPoolSet method check if the Pool field of PoolCreate object is set.
 func IsPoolSet() PredicateFunc {
 	return func(p *PoolCreate) bool {


### PR DESCRIPTION
commit fixes the zpool create cmd with `compression` as a filesystem
property with `-O` which is failed due to `-o` used earlier

cmd example:

```sh 
zpool create -o cachefile=/var/openebs/cstor-poolpool.cache -O compression=lz4
cstor-b662a561-3c89-4eec-b6f0-a19ee12004a2 /var/openebs/sparse/4-ndm-sparse.img
```
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>