### PR TITLE
[WIP]chore(sanity_bdd): add sanity test for cspc

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,6 +26,7 @@ jobs:
       run: make test
       env:
         GOPATH: /home/runner/work/cstor-operators/go
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ deps:
 
 .PHONY: test
 test:
-	go test ./...
+	# "Skipping tests under tests directory. These tests can be run via ginkgo cli."
+	go test `go list ./... | grep -v tests` 
 
 cvc-operator:
 	@echo -n "--> cvc-operator <--"
@@ -130,3 +131,6 @@ cstor-webhook-image:
 	@cp bin/${CSTOR_WEBHOOK}/${WEBHOOK_REPO} build/cstor-webhook/
 	@cd build/${CSTOR_WEBHOOK} && sudo docker build -t ${HUB_USER}/${CSTOR_WEBHOOK}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm build/${CSTOR_WEBHOOK}/${WEBHOOK_REPO}
+
+.PHONY: images
+images: cspc-operator-image pool-manager-image cstor-webhook-image cvc-operator-image cvc-operator-image.arm64 volume-manager-image

--- a/hack/minikube.sh
+++ b/hack/minikube.sh
@@ -1,0 +1,34 @@
+# Copyright 2020 The OpenEBS Authors.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/usr/bin/env bash
+echo "Downloading Kubectl Binary..."
+curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+sudo chmod +x ./kubectl
+sudo mv ./kubectl /usr/local/bin/kubectl
+echo "Kubectl Client Version..."
+kubectl version --client
+
+echo "Downloading Minikube Binary..."
+curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 \
+  && chmod +x minikube
+
+sudo mkdir -p /usr/local/bin/
+sudo install minikube /usr/local/bin/
+
+echo "Minikube Version..."
+
+minikube version
+
+sudo minikube start --vm-driver=none --kubernetes-version=v1.16.0

--- a/tests/cspc/sanity/cspc_sanity_test.go
+++ b/tests/cspc/sanity/cspc_sanity_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sanity_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
+	"github.com/openebs/api/pkg/apis/types"
+	"github.com/openebs/cstor-operators/tests/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestSource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CSPC Sanity Tests")
+}
+
+func init() {
+	client.ParseFlags()
+}
+
+var clientSet *client.Client
+
+var _ = BeforeSuite(func() {
+	var err error
+	clientSet, err = client.NewClient(client.KubeConfigPath)
+	Expect(err).To(BeNil())
+	NodeList, err := clientSet.KubeClientSet.CoreV1().Nodes().List(metav1.ListOptions{})
+	Expect(err).To(BeNil())
+	Expect(len(NodeList.Items)).Should(BeNumerically(">=", 1))
+})
+
+var _ = Describe("CSPC Stripe On One Node", func() {
+
+	var cspc *cstor.CStorPoolCluster
+	Describe("Provisioning and cleanup of CSPC", func() {
+
+		Context("Creating a cspc", func() {
+
+			Specify("no error should be returned", func() {
+				cspc = getCSPCSpec()
+				_, err := clientSet.OpenEBSClientSet.CstorV1().CStorPoolClusters(cspc.Namespace).Create(cspc)
+				Expect(err).To(BeNil())
+			})
+
+			Specify("desired count should be 1 on cspc", func() {
+				gotCount := clientSet.GetDesiredInstancesStatusOnCSPC(cspc.Name, cspc.Namespace, 1)
+				Expect(gotCount).To(BeNumerically("==", 1))
+			})
+
+		})
+
+		Context("All the cspi(s) of the cspc", func() {
+			It("Should be healthy", func() {
+				gotHealthyCSPiCount := clientSet.GetOnlineCSPICountEventually(cspc.Name, cspc.Namespace, 1)
+				Expect(gotHealthyCSPiCount).To(BeNumerically("==", 1))
+			})
+		})
+
+		Context("Staus of the cspc i.e. provisionedInstances and healthyInstances ", func() {
+			It("Should be updated", func() {
+				gotProvisionedCount := clientSet.GetProvisionedInstancesStatusOnCSPC(cspc.Name, cspc.Namespace, 1)
+				Expect(gotProvisionedCount).To(BeNumerically("==", 1))
+
+				gotHealthyCount := clientSet.GetHealthyInstancesStatusOnCSPC(cspc.Name, cspc.Namespace, 1)
+				Expect(gotHealthyCount).To(BeNumerically("==", 1))
+			})
+		})
+
+		Context("Deleting the cspc", func() {
+
+			It("No error should be returned", func() {
+				err := clientSet.OpenEBSClientSet.CstorV1().CStorPoolClusters(cspc.Namespace).Delete(cspc.Name, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			})
+
+			It("No corresponding cspi(s) should be present", func() {
+				gotCSPICount := clientSet.GetCSPICountEventually(cspc.Name, cspc.Namespace, 0)
+				Expect(gotCSPICount).To(BeNumerically("==", 0))
+			})
+
+			It("No corresponding pool-manger deployments should be present", func() {
+				gotPoolMangerCount := clientSet.GetPoolManagerCountEventually(cspc.Name, cspc.Namespace, 0)
+				Expect(gotPoolMangerCount).To(BeNumerically("==", 0))
+			})
+
+			It("the bdc(s) created by cstor-operator should get deleted", func() {
+				gotCount := clientSet.GetBDCCountEventually(cspc.Name, cspc.Namespace, 0)
+				Expect(gotCount).To(BeNumerically("==", 0))
+			})
+		})
+	})
+
+})
+
+func getNodeSelector() map[string]string {
+	nodes, err := clientSet.KubeClientSet.CoreV1().Nodes().List(metav1.ListOptions{})
+	Expect(err).To(BeNil())
+	Expect(len(nodes.Items)).To(BeNumerically(">=", 1))
+	// pick a node
+	node := nodes.Items[0]
+	newLabels := make(map[string]string)
+	newLabels[types.HostNameLabelKey] = node.Labels[types.HostNameLabelKey]
+	return newLabels
+}
+
+func getBDName(nodeSelector map[string]string) string {
+	bdList, err := clientSet.OpenEBSClientSet.OpenebsV1alpha1().BlockDevices("openebs").
+		List(metav1.ListOptions{LabelSelector: types.HostNameLabelKey + "=" + nodeSelector[types.HostNameLabelKey]})
+	Expect(err).To(BeNil())
+	Expect(len(bdList.Items)).To(BeNumerically(">=", 1))
+	bd := bdList.Items[0]
+	return bd.Name
+}
+
+func getCSPCSpec() *cstor.CStorPoolCluster {
+	nodeSelector := getNodeSelector
+	Expect(nodeSelector()).ToNot(BeNil())
+	cspc := cstor.NewCStorPoolCluster().
+		WithName("cspc-foo").
+		WithNamespace("openebs").
+		WithPoolSpecs(
+			*cstor.NewPoolSpec().
+				WithNodeSelector(getNodeSelector()).
+				WithDataRaidGroups(
+					*cstor.NewRaidGroup().
+						WithCStorPoolInstanceBlockDevices(
+							*cstor.NewCStorPoolInstanceBlockDevice().
+								WithName(getBDName(nodeSelector())),
+						),
+				).
+				WithPoolConfig(*cstor.NewPoolConfig().WithDataRaidGroupType("stripe")),
+		)
+	return cspc
+}

--- a/tests/pkg/client/client.go
+++ b/tests/pkg/client/client.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"flag"
+	openebsclientset "github.com/openebs/api/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog"
+)
+
+type Client struct {
+	// kubeclientset is a standard kubernetes clientset
+	KubeClientSet kubernetes.Interface
+
+	// clientset is a openebs custom resource package generated for custom API group.
+	OpenEBSClientSet openebsclientset.Interface
+}
+
+var (
+	// KubeConfigPath is the path to
+	// the kubeconfig provided at runtime
+	KubeConfigPath string
+)
+
+// ParseFlags gets the flag values at run time
+func ParseFlags() {
+	flag.StringVar(&KubeConfigPath, "kubeconfig", "", "path to kubeconfig to invoke kubernetes API calls")
+}
+
+func NewClient(path string) (*Client, error) {
+	klog.InitFlags(nil)
+	err := flag.Set("logtostderr", "true")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to set logtostderr flag")
+	}
+
+	cfg, err := getClusterConfig(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "error building kubeconfig")
+	}
+	// Building Kubernetes Clientset
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "error building kubernetes clientset")
+	}
+
+	// Building OpenEBS Clientset
+	openebsClient, err := openebsclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "error building openebs clientset")
+	}
+
+	client := &Client{
+		KubeClientSet:    kubeClient,
+		OpenEBSClientSet: openebsClient,
+	}
+
+	return client, nil
+
+}
+
+// GetClusterConfig return the config for k8s.
+func getClusterConfig(kubeconfig string) (*rest.Config, error) {
+	if kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	klog.V(2).Info("Kubeconfig flag is empty")
+	return rest.InClusterConfig()
+}

--- a/tests/pkg/client/cspc_operations.go
+++ b/tests/pkg/client/cspc_operations.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	. "github.com/onsi/gomega"
+	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
+	"github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/api/pkg/apis/types"
+	"k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"time"
+)
+
+const maxRetry = 30
+
+// GetHealthyCSPICountEventually gets online cspi(s) based on cspc name
+func (client *Client) GetOnlineCSPICountEventually(cspcName, cspcNamespace string, expectedCSPICount int) int {
+	var cspiCount int
+	// as cspi deletion takes more time now for cleanup of its resources
+	// for reconciled cspi to come up it can take additional time.
+	for i := 0; i < (maxRetry + 100); i++ {
+		cspiList := client.GetCSPIList(cspcName, cspcNamespace)
+		filteredList := cspiList.Filter(cstor.IsOnline())
+		cspiCount = len(filteredList.Items)
+		if cspiCount == expectedCSPICount {
+			return cspiCount
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return cspiCount
+}
+
+// GetCSPICountEventually gets cspi(s) based on cspc name
+func (client *Client) GetCSPICountEventually(cspcName, cspcNamespace string, expectedCSPICount int) int {
+	var cspiCount int
+	for i := 0; i < (maxRetry + 100); i++ {
+		cspiList := client.GetCSPIList(cspcName, cspcNamespace)
+		cspiCount = len(cspiList.Items)
+		if cspiCount == expectedCSPICount {
+			return cspiCount
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return cspiCount
+}
+
+// GetPoolManagerCountEventually gets the pool-manager deployment count based on cspc name
+func (client *Client) GetPoolManagerCountEventually(cspcName, cspcNamespace string, expectedCSPICount int) int {
+	var pmCount int
+	for i := 0; i < (maxRetry + 100); i++ {
+		pmList := client.GetPoolManagerList(cspcName, cspcNamespace)
+		pmCount = len(pmList.Items)
+		if pmCount == expectedCSPICount {
+			return pmCount
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return pmCount
+}
+
+// GetBDCCountEventually gets the bdc count based on cspc name and namespace
+func (client *Client) GetBDCCountEventually(cspcName, cspcNamespace string, expectedBDCCount int) int {
+	var bdcCount int
+	for i := 0; i < (maxRetry + 100); i++ {
+		bdcList := client.GetBDCList(cspcName, cspcNamespace)
+		bdcCount = len(bdcList.Items)
+		if bdcCount == expectedBDCCount {
+			return bdcCount
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return bdcCount
+}
+
+// GetProvisionedInstancesStatusOnCSPC gets provisioned instances count based on cspc name
+// and namespace.
+func (client *Client) GetProvisionedInstancesStatusOnCSPC(cspcName, cspcNamespace string,
+	expectedProvisionedInstancesStatus int32) int32 {
+	var gotProvisionedInstances int32
+	for i := 0; i < (maxRetry + 100); i++ {
+		cspc := client.GetCSPC(cspcName, cspcNamespace)
+		gotProvisionedInstances = cspc.Status.ProvisionedInstances
+		if gotProvisionedInstances == expectedProvisionedInstancesStatus {
+			return gotProvisionedInstances
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return gotProvisionedInstances
+}
+
+// GetHealthyInstancesStatusOnCSPC gets healthy instances count based on cspc name
+// and namespace.
+func (client *Client) GetHealthyInstancesStatusOnCSPC(cspcName, cspcNamespace string,
+	expectedHealthyInstancesStatus int32) int32 {
+	var gotHealthyInstances int32
+	for i := 0; i < (maxRetry + 100); i++ {
+		cspc := client.GetCSPC(cspcName, cspcNamespace)
+		gotHealthyInstances = cspc.Status.HealthyInstances
+		if gotHealthyInstances == expectedHealthyInstancesStatus {
+			return gotHealthyInstances
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return gotHealthyInstances
+}
+
+// GetDesiredInstancesStatusOnCSPC gets desired instances count based on cspc name
+// and namespace.
+func (client *Client) GetDesiredInstancesStatusOnCSPC(cspcName, cspcNamespace string,
+	expectedDesiredInstancesStatus int32) int32 {
+	var gotDesiredInstances int32
+	for i := 0; i < (maxRetry + 100); i++ {
+		cspc := client.GetCSPC(cspcName, cspcNamespace)
+		gotDesiredInstances = cspc.Status.DesiredInstances
+		if gotDesiredInstances == expectedDesiredInstancesStatus {
+			return gotDesiredInstances
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return gotDesiredInstances
+}
+
+// GetCSPIList gets the list of all cspi(s) based on cspc name and namespace.
+func (client *Client) GetCSPIList(cspcName, cspcNamespace string) *cstor.CStorPoolInstanceList {
+	cspiList, err := client.OpenEBSClientSet.CstorV1().
+		CStorPoolInstances(cspcNamespace).
+		List(metav1.ListOptions{LabelSelector: types.CStorPoolClusterLabelKey + "=" + cspcName})
+	Expect(err).To(BeNil())
+	return cspiList
+}
+
+// GetPoolManagerList gets the list of all pool-manger deployments based on cspc name and namespace.
+func (client *Client) GetPoolManagerList(cspcName, cspcNamespace string) *v1.DeploymentList {
+	pmList, err := client.KubeClientSet.AppsV1().
+		Deployments(cspcNamespace).
+		List(metav1.ListOptions{LabelSelector: types.CStorPoolClusterLabelKey + "=" + cspcName})
+	Expect(err).To(BeNil())
+	return pmList
+}
+
+// GetBDCList gets the list of all bdc(s) based on cspc name and namespace.
+func (client *Client) GetBDCList(cspcName, cspcNamespace string) *v1alpha1.BlockDeviceClaimList {
+	bdcList, err := client.OpenEBSClientSet.OpenebsV1alpha1().
+		BlockDeviceClaims(cspcNamespace).
+		List(metav1.ListOptions{LabelSelector: types.CStorPoolClusterLabelKey + "=" + cspcName})
+	Expect(err).To(BeNil())
+	return bdcList
+}
+
+// GetPoolManagerList gets the list of all pool-manger deployments based on cspc name and namespace.
+func (client *Client) GetCSPC(cspcName, cspcNamespace string) *cstor.CStorPoolCluster {
+	cspc, err := client.OpenEBSClientSet.CstorV1().CStorPoolClusters(cspcNamespace).Get(cspcName, metav1.GetOptions{})
+	Expect(err).To(BeNil())
+	return cspc
+}

--- a/tests/readme.md
+++ b/tests/readme.md
@@ -1,0 +1,37 @@
+Behavior Driven Development(BDD)
+
+Maya makes use of ginkgo & gomega libraries to implement its integration tests.
+
+To run the BDD test:
+1) Copy kubeconfig file into path ~/.kube/config or set the KUBECONFIG env.
+2) Change the current directory path to test related directory
+
+Example:
+
+To trigger the cspc sanity test
+
+Step1: Go to the root directory of the cstor-operators repo.
+       The current directory should be "*/github.com/openebs/cstor-operator/tests/" 
+       in this case
+       
+Step2: Execute the command `ginkgo -v -r tests/ -- -kubeconfig=/path/to/kubeconfig`
+
+Output:
+Sample example output
+```
+Running Suite: CSPC Sanity Tests
+================================
+Random Seed: 1586813951
+Will run 8 of 8 specs
+
+CSPC Stripe On One Node Provisioning and cleanup of CSPC Creating a cspc 
+  no error should be returned
+  /home/ashutosh/go/src/github.com/openebs/cstor-operators/tests/cspc/sanity/cspc_sanity_test.go:68
+•
+------------------------------
+CSPC Stripe On One Node Provisioning and cleanup of CSPC Creating a cspc 
+  desired count should be 1 on cspc
+  /home/ashutosh/go/src/github.com/openebs/cstor-operators/tests/cspc/sanity/cspc_sanity_test.go:74
+
+```
+Note: Above is the sample output how it looks when you ran `ginkgo -v -r tests/ -- -kubeconfig=/path/to/kubeconfig`


### PR DESCRIPTION
This PR does the following: 

1. Adds github-actions workflow to setup minikube to run BDDs.
2. Adds cspc sanity BDD.

*Note:* 
PR https://github.com/openebs/api/pull/38 is a pre-requisite and should be merged before.
After the PR is merged -- the update API changes need to be vendor-ed here and then this 
PR can be merged.
This process of vendor-ing will be automated in subsequent PRs and is out of the scope of this PR.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>