### PR TITLE
fix(operator): use single service account for deployments

### DIFF
--- a/build/cspc-operator/Dockerfile
+++ b/build/cspc-operator/Dockerfile
@@ -21,7 +21,7 @@ ARG BUILD_DATE
 LABEL org.label-schema.name="cspc-operator"
 LABEL org.label-schema.description="CSPC Operator for OpenEBS cStor engine"
 LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 

--- a/build/cvc-operator/Dockerfile
+++ b/build/cvc-operator/Dockerfile
@@ -16,7 +16,7 @@ ARG BUILD_DATE
 LABEL org.label-schema.name="cvc-operator"
 LABEL org.label-schema.description="Operator for OpenEBS cStor csi volumes"
 LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 

--- a/build/cvc-operator/Dockerfile.arm64
+++ b/build/cvc-operator/Dockerfile.arm64
@@ -19,7 +19,7 @@ ARG BUILD_DATE
 LABEL org.label-schema.name="cvc-operator"
 LABEL org.label-schema.description="Operator for OpenEBS cStor csi volumes"
 LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 

--- a/build/pool-manager/Dockerfile
+++ b/build/pool-manager/Dockerfile
@@ -22,7 +22,7 @@ ARG BUILD_DATE
 LABEL org.label-schema.name="cstor-pool-manager"
 LABEL org.label-schema.description="OpenEBS"
 LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 

--- a/build/volume-manager/Dockerfile
+++ b/build/volume-manager/Dockerfile
@@ -18,7 +18,7 @@ ARG BUILD_DATE
 LABEL org.label-schema.name="cstor-volume-manager"
 LABEL org.label-schema.description="OpenEBS"
 LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 

--- a/build/volume-manager/Dockerfile.arm64
+++ b/build/volume-manager/Dockerfile.arm64
@@ -22,7 +22,7 @@ ARG BUILD_DATE
 LABEL org.label-schema.name="cstor-volume-mgmt"
 LABEL org.label-schema.description="OpenEBS"
 LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/maya"
+LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 

--- a/deploy/cstor-operator.yaml
+++ b/deploy/cstor-operator.yaml
@@ -23,7 +23,7 @@ spec:
         openebs.io/component-name: cspc-operator
         openebs.io/version: dev
     spec:
-      serviceAccountName: openebs-cstor-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: cspc-operator
         imagePullPolicy: IfNotPresent
@@ -85,7 +85,7 @@ spec:
         openebs.io/component-name: cvc-operator
         openebs.io/version: dev
     spec:
-      serviceAccountName: openebs-cstor-operator
+      serviceAccountName: openebs-maya-operator
       containers:
       - name: cvc-operator
         imagePullPolicy: IfNotPresent
@@ -118,7 +118,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: openebs-admission-server
+  name: cstor-admission-server
   namespace: openebs
   labels:
     app: admission-webhook
@@ -139,7 +139,7 @@ spec:
         openebs.io/component-name: admission-webhook
         openebs.io/version: dev
     spec:
-      serviceAccountName: openebs-cstor-operator
+      serviceAccountName: openebs-maya-operator
       containers:
         - name: admission-webhook
           image: openebs/cstor-webhook-amd64:ci
@@ -154,4 +154,4 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ADMISSION_WEBHOOK_NAME
-              value: "openebs-admission-server"
+              value: "cstor-admission-server"

--- a/deploy/cstor-operator.yaml
+++ b/deploy/cstor-operator.yaml
@@ -118,11 +118,11 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: cstor-admission-server
+  name: openebs-cstor-admission-server
   namespace: openebs
   labels:
-    app: admission-webhook
-    openebs.io/component-name: admission-webhook
+    app: cstor-admission-webhook
+    openebs.io/component-name: cstor-admission-webhook
     openebs.io/version: dev
 spec:
   replicas: 1
@@ -131,12 +131,12 @@ spec:
     rollingUpdate: null
   selector:
     matchLabels:
-      app: admission-webhook
+      app: cstor-admission-webhook
   template:
     metadata:
       labels:
-        app: admission-webhook
-        openebs.io/component-name: admission-webhook
+        app: cstor-admission-webhook
+        openebs.io/component-name: cstor-admission-webhook
         openebs.io/version: dev
     spec:
       serviceAccountName: openebs-maya-operator
@@ -154,4 +154,4 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: ADMISSION_WEBHOOK_NAME
-              value: "cstor-admission-server"
+              value: "openebs-cstor-admission-server"

--- a/deploy/ndm-operator.yaml
+++ b/deploy/ndm-operator.yaml
@@ -71,7 +71,7 @@ spec:
       # kubectl label node <node-name> "openebs.io/nodegroup"="storage-node"
       #nodeSelector:
       #  "openebs.io/nodegroup": "storage-node"
-      serviceAccountName: openebs-cstor-operator
+      serviceAccountName: openebs-maya-operator
       hostNetwork: true
       containers:
       - name: node-disk-manager
@@ -162,10 +162,10 @@ spec:
         openebs.io/component-name: ndm-operator
         openebs.io/version: dev
     spec:
-      serviceAccountName: openebs-cstor-operator
+      serviceAccountName: openebs-maya-operator
       containers:
         - name: node-disk-operator
-          image: openebs/node-disk-operator-amd64:v0.4.8
+          image: openebs/node-disk-operator-amd64:v0.4.9
           imagePullPolicy: IfNotPresent
           readinessProbe:
             exec:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -8,7 +8,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: openebs-cstor-operator
+  name: openebs-maya-operator
   namespace: openebs
 ---
 # Define Role that allows operations on K8s pods/deployments
@@ -72,14 +72,13 @@ rules:
   verbs: ["get", "list", "create", "delete", "watch"]
 ---
 # Bind the Service Account with the Role Privileges.
-# TODO: Check if default account also needs to be there
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: openebs-cstor-operator
 subjects:
 - kind: ServiceAccount
-  name: openebs-cstor-operator
+  name: openebs-maya-operator
   namespace: openebs
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
- commit changes to use openebs-maya-operator service account for all cstor deployments.
- Add `openebs-cstor-operator` clusterRole and ClusterRolebindings to main `openebs-maya-operator ` service account

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>