### PR TITLE
chore(push_script): refactor makefile and push scirpt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-HUB_USER?=openebs
+IMAGE_ORG?=openebs
 
 # Determine the arch/os
 ifeq (${XC_OS}, )
@@ -100,63 +100,63 @@ cvc-operator:
 .PHONY: cvc-operator-image.amd64
 cvc-operator-image.amd64:
 	@echo -n "--> cvc-operator image <--"
-	@echo "${HUB_USER}/${CVC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
+	@echo "${IMAGE_ORG}/${CVC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
 	@PNAME=${CVC_OPERATOR} CTLNAME=${CVC_OPERATOR} sh -c "'$(PWD)/build/build.sh'"
 	@cp bin/${CVC_OPERATOR}/${CVC_OPERATOR} build/cvc-operator/
-	@cd build/${CVC_OPERATOR} && sudo docker build -t ${HUB_USER}/${CVC_OPERATOR_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd build/${CVC_OPERATOR} && sudo docker build -t ${IMAGE_ORG}/${CVC_OPERATOR_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm build/${CVC_OPERATOR}/${CVC_OPERATOR}
 
 .PHONY: cvc-operator-image.arm64
 cvc-operator-image.arm64:
 	@echo "----------------------------"
 	@echo -n "--> arm64 based cvc-operator image "
-	@echo "${HUB_USER}/${CVC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
+	@echo "${IMAGE_ORG}/${CVC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
 	@PNAME=${CVC_OPERATOR} CTLNAME=${CVC_OPERATOR} sh -c "'$(PWD)/build/build.sh'"
 	@cp bin/${CVC_OPERATOR}/${CVC_OPERATOR} build/cvc-operator/
-	@cd build/${CVC_OPERATOR} && sudo docker build -t ${HUB_USER}/${CVC_OPERATOR_ARM64}:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd build/${CVC_OPERATOR} && sudo docker build -t ${IMAGE_ORG}/${CVC_OPERATOR_ARM64}:${IMAGE_TAG} -f Dockerfile.arm64 --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm build/${CVC_OPERATOR}/${CVC_OPERATOR}
 
 .PHONY: volume-manager-image.amd64
 volume-manager-image.amd64:
 	@echo -n "--> volume manager image <--"
-	@echo "${HUB_USER}/${VOLUME_MANAGER_REPO_NAME}:${IMAGE_TAG}"
+	@echo "${IMAGE_ORG}/${VOLUME_MANAGER_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
 	@PNAME=${VOLUME_MANAGER} CTLNAME=${VOLUME_MANAGER} sh -c "'$(PWD)/build/build.sh'"
 	@cp bin/${VOLUME_MANAGER}/${VOLUME_MANAGER} build/volume-manager/
-	@cd build/${VOLUME_MANAGER} && sudo docker build -t ${HUB_USER}/${VOLUME_MANAGER_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd build/${VOLUME_MANAGER} && sudo docker build -t ${IMAGE_ORG}/${VOLUME_MANAGER_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm build/${VOLUME_MANAGER}/${VOLUME_MANAGER}
 
 .PHONY: cspc-operator-image.amd64
 cspc-operator-image.amd64:
 	@echo -n "--> cspc-operator image <--"
-	@echo "${HUB_USER}/${CSPC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
+	@echo "${IMAGE_ORG}/${CSPC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
 	@PNAME=${CSPC_OPERATOR} CTLNAME=${CSPC_OPERATOR} sh -c "'$(PWD)/build/build.sh'"
 	@cp bin/${CSPC_OPERATOR}/${CSPC_OPERATOR} build/cspc-operator/
-	@cd build/${CSPC_OPERATOR} && sudo docker build -t ${HUB_USER}/${CSPC_OPERATOR_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd build/${CSPC_OPERATOR} && sudo docker build -t ${IMAGE_ORG}/${CSPC_OPERATOR_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm build/${CSPC_OPERATOR}/${CSPC_OPERATOR}
 
 .PHONY: pool-manager-image.amd64
 pool-manager-image.amd64:
 	@echo -n "--> pool manager image <--"
-	@echo "${HUB_USER}/${POOL_MANAGER_REPO_NAME}:${IMAGE_TAG}"
+	@echo "${IMAGE_ORG}/${POOL_MANAGER_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
 	@PNAME=${POOL_MANAGER} CTLNAME=${POOL_MANAGER} sh -c "'$(PWD)/build/build.sh'"
 	@cp bin/${POOL_MANAGER}/${POOL_MANAGER} build/pool-manager/
-	@cd build/${POOL_MANAGER} && sudo docker build -t ${HUB_USER}/${POOL_MANAGER_REPO_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE} --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
+	@cd build/${POOL_MANAGER} && sudo docker build -t ${IMAGE_ORG}/${POOL_MANAGER_REPO_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE} --build-arg BUILD_DATE=${BUILD_DATE} . --no-cache
 	@rm build/${POOL_MANAGER}/${POOL_MANAGER}
 
 .PHONY: cstor-webhook-image.amd64
 cstor-webhook-image.amd64:
 	@echo "----------------------------"
 	@echo -n "--> cstor-webhook image "
-	@echo "${HUB_USER}/${CSTOR_WEBHOOK_REPO_NAME}:${IMAGE_TAG}"
+	@echo "${IMAGE_ORG}/${CSTOR_WEBHOOK_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
 	@PNAME=${CSTOR_WEBHOOK} CTLNAME=${WEBHOOK_REPO} sh -c "'$(PWD)/build/build.sh'"
 	@cp bin/${CSTOR_WEBHOOK}/${WEBHOOK_REPO} build/cstor-webhook/
-	@cd build/${CSTOR_WEBHOOK} && sudo docker build -t ${HUB_USER}/${CSTOR_WEBHOOK_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
+	@cd build/${CSTOR_WEBHOOK} && sudo docker build -t ${IMAGE_ORG}/${CSTOR_WEBHOOK_REPO_NAME}:${IMAGE_TAG} --build-arg BUILD_DATE=${BUILD_DATE} .
 	@rm build/${CSTOR_WEBHOOK}/${WEBHOOK_REPO}
 
 .PHONY: all.amd64

--- a/build/cspc-operator/Dockerfile
+++ b/build/cspc-operator/Dockerfile
@@ -16,13 +16,18 @@ RUN apk add --no-cache \
 
 COPY cspc-operator /usr/local/bin/cspc-operator
 
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
 
-ARG BUILD_DATE
 LABEL org.label-schema.name="cspc-operator"
 LABEL org.label-schema.description="CSPC Operator for OpenEBS cStor engine"
 LABEL org.label-schema.url="http://www.openebs.io/"
 LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT ["/usr/local/bin/cspc-operator"]

--- a/build/cstor-webhook/Dockerfile
+++ b/build/cstor-webhook/Dockerfile
@@ -6,13 +6,20 @@ RUN apt-get update && apt-get install -y \
 ADD webhook /usr/local/bin/webhook
 
 
-ARG BUILD_DATE
+
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 LABEL org.label-schema.name="cstor-webhook"
-LABEL org.label-schema.description="webhook admission server policy for CStor"
+LABEL org.label-schema.description="Webhook admission server for cStor"
 LABEL org.label-schema.url="http://www.openebs.io/"
 LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT ["/usr/local/bin/webhook"]
 

--- a/build/cvc-operator/Dockerfile
+++ b/build/cvc-operator/Dockerfile
@@ -12,12 +12,18 @@ RUN apk add --no-cache \
 
 COPY cvc-operator /usr/local/bin/cvc-operator
 
-ARG BUILD_DATE
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 LABEL org.label-schema.name="cvc-operator"
 LABEL org.label-schema.description="Operator for OpenEBS cStor csi volumes"
 LABEL org.label-schema.url="http://www.openebs.io/"
 LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT ["/usr/local/bin/cvc-operator"]

--- a/build/cvc-operator/Dockerfile.arm64
+++ b/build/cvc-operator/Dockerfile.arm64
@@ -15,12 +15,18 @@ RUN apk add --no-cache \
 
 COPY cvc-operator /usr/local/bin/cvc-operator
 
-ARG BUILD_DATE
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 LABEL org.label-schema.name="cvc-operator"
 LABEL org.label-schema.description="Operator for OpenEBS cStor csi volumes"
 LABEL org.label-schema.url="http://www.openebs.io/"
 LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT ["/usr/local/bin/cvc-operator"]

--- a/build/pool-manager/Dockerfile
+++ b/build/pool-manager/Dockerfile
@@ -18,13 +18,19 @@ RUN chmod +x /usr/local/bin/execute.sh
 RUN apt install netcat -y
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-ARG BUILD_DATE
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 LABEL org.label-schema.name="cstor-pool-manager"
-LABEL org.label-schema.description="OpenEBS"
+LABEL org.label-schema.description="Pool manager for cStor pool"
 LABEL org.label-schema.url="http://www.openebs.io/"
 LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT entrypoint.sh
 EXPOSE 7676

--- a/build/push
+++ b/build/push
@@ -80,7 +80,11 @@ then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
-    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG}"
+    # Trim the `v` from the TRAVIS_TAG if it exists
+    # Example: v1.10.0 maps to 1.10.0
+    # Example: 1.10.0 maps to 1.10.0
+    # Example: v1.10.0-custom maps to 1.10.0-custom
+    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG#v}"
     TagAndPushImage "${DIMAGE}" "latest"
   fi;
 else
@@ -100,7 +104,11 @@ then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
-    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG}"
+    # Trim the `v` from the TRAVIS_TAG if it exists
+    # Example: v1.10.0 maps to 1.10.0
+    # Example: 1.10.0 maps to 1.10.0
+    # Example: v1.10.0-custom maps to 1.10.0-custom
+    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG#v}"
     TagAndPushImage "quay.io/${DIMAGE}" "latest"
   fi;
 else

--- a/build/push
+++ b/build/push
@@ -55,9 +55,17 @@ echo "Set the build/unique image tag as: ${BUILD_TAG}"
 
 function TagAndPushImage() {
   REPO="$1"
-  TAG="$2"
+  # Trim the `v` from the TAG if it exists
+  # Example: v1.10.0 maps to 1.10.0
+  # Example: 1.10.0 maps to 1.10.0
+  # Example: v1.10.0-custom maps to 1.10.0-custom
+  TAG="${2#v}"
 
-  IMAGE_URI="${REPO}:${TAG}";
+  # Add an option to specify a custom TAG_SUFFIX
+  # via environment variable. Default is no tag.
+  # Example suffix could be "-debug" of "-dev"
+  IMAGE_URI="${REPO}:${TAG}${TAG_SUFFIX}";
+
   sudo docker tag ${IMAGEID} ${IMAGE_URI};
   echo " push ${IMAGE_URI}";
   sudo docker push ${IMAGE_URI};
@@ -80,11 +88,7 @@ then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
-    # Trim the `v` from the TRAVIS_TAG if it exists
-    # Example: v1.10.0 maps to 1.10.0
-    # Example: 1.10.0 maps to 1.10.0
-    # Example: v1.10.0-custom maps to 1.10.0-custom
-    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG#v}"
+    TagAndPushImage "${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "${DIMAGE}" "latest"
   fi;
 else
@@ -104,11 +108,7 @@ then
     # Push with different tags if tagged as a release
     # When github is tagged with a release, then Travis will
     # set the release tag in env TRAVIS_TAG
-    # Trim the `v` from the TRAVIS_TAG if it exists
-    # Example: v1.10.0 maps to 1.10.0
-    # Example: 1.10.0 maps to 1.10.0
-    # Example: v1.10.0-custom maps to 1.10.0-custom
-    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG#v}"
+    TagAndPushImage "quay.io/${DIMAGE}" "${TRAVIS_TAG}"
     TagAndPushImage "quay.io/${DIMAGE}" "latest"
   fi;
 else

--- a/build/volume-manager/Dockerfile
+++ b/build/volume-manager/Dockerfile
@@ -14,13 +14,20 @@ COPY entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-ARG BUILD_DATE
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 LABEL org.label-schema.name="cstor-volume-manager"
-LABEL org.label-schema.description="OpenEBS"
+LABEL org.label-schema.description="Volume manager for cStor volumes"
 LABEL org.label-schema.url="http://www.openebs.io/"
 LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT entrypoint.sh
 EXPOSE 7676 7777

--- a/build/volume-manager/Dockerfile.arm64
+++ b/build/volume-manager/Dockerfile.arm64
@@ -18,13 +18,19 @@ COPY entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
-ARG BUILD_DATE
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
 LABEL org.label-schema.name="cstor-volume-mgmt"
-LABEL org.label-schema.description="OpenEBS"
+LABEL org.label-schema.description="Volume manager for cStor volumes"
 LABEL org.label-schema.url="http://www.openebs.io/"
 LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
-LABEL org.label-schema.build-date=$BUILD_DATE
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
 
 ENTRYPOINT entrypoint.sh
 EXPOSE 7676 7777


### PR DESCRIPTION
This PR does the following :

1. The container images should be pushed without a `v` in the tag SEMVER.
     The refactors script to trims the leading `v` before pushing 

2. Change the env variable `HUB_USER` to `IMAGE_ORG` for consistency across openebs repos.
   This variable holds the image repository user name.

3. Modifies the Dockerfiles to add the required labels.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>