### PR TITLE
refact(build): fix cstor base image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ifeq (${TRAVIS_TAG}, )
   BASE_TAG = ci
   export BASE_TAG
 else
-  BASE_TAG = ${TRAVIS_TAG}
+  BASE_TAG = ${TRAVIS_TAG#v}
   export BASE_TAG
 endif
 


### PR DESCRIPTION
**What this PR does**:

The docker tags are created by removing the v from
prefix of TRAVIS_TAG (github tag). Using TRAVIS_TAG
to fetch cstor base image fails to build cstor related
containers.

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>