### PR TITLE
fix(Makefile): update the expression to trim 'v' from tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ifeq (${TRAVIS_TAG}, )
   BASE_TAG = ci
   export BASE_TAG
 else
-  BASE_TAG = ${TRAVIS_TAG#v}
+  BASE_TAG = $(TRAVIS_TAG:v%=%)
   export BASE_TAG
 endif
 


### PR DESCRIPTION
commit update the trim expression in Makefile which is failing
with the error unterminated variable reference due to error
in parsing expression

Similar logic works in bash script but not in Makefiles

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>