### PR TITLE
chore(log): add cspc information in error event

### DIFF
--- a/pkg/controllers/cstorvolumeconfig/volume_operations.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations.go
@@ -361,7 +361,12 @@ func (c *CVCController) distributeCVRs(
 	}
 
 	if len(usablePoolList.Items) < pendingReplicaCount {
-		return errors.New("not enough pools available to create replicas")
+		return errors.Errorf(
+			"not enough pools are available of provided CSPC: %q, usable pool count: %d pending replica count: %d",
+			cspcName,
+			len(usablePoolList.Items),
+			pendingReplicaCount,
+		)
 	}
 
 	for count, pool := range usablePoolList.Items {


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR adds the CPSC information in the error log. When the user Provision a volume with storage replciaCount > no.of available pools (or) when the user mentioned a typo of CSPC name then event will be shown.