### PR TITLE
fix(cspi): import pool without cachefile

### DIFF
--- a/ci/sanity/sanity.sh
+++ b/ci/sanity/sanity.sh
@@ -136,7 +136,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 ## verify whether cache file present in persistent path
-ls -lrth /var/openebs/cstor-pool/${cspc_name}/pool.cache
+ls -lrth /var/openebs/cstor-pool/${cspcName}/pool.cache
 if [ $? -ne 0 ]; then
     echo "cache file is not present in persistent path"
     exit 1

--- a/ci/sanity/sanity.sh
+++ b/ci/sanity/sanity.sh
@@ -127,6 +127,21 @@ kubectl apply -f ./ci/sanity/cspc.yaml
 
 IsPoolHealthy 30
 
+## Once the pool is healthy verify whether cachefile stored in persistent path
+## Get the CSPC name
+echo "Verifying whether pool cachefile is stored in persistent path"
+cspcName=$(kubectl get cspc -n openebs -o jsonpath={.items[0].metadata.name})
+if [ $? -ne 0 ]; then
+    echo "Failed to get CSPC name"
+    exit 1
+fi
+## verify whether cache file present in persistent path
+ls -lrth /var/openebs/cstor-pool/${cspc_name}/pool.cache
+if [ $? -ne 0 ]; then
+    echo "cache file is not present in persistent path"
+    exit 1
+fi
+
 echo "Applying cstor-csi storage class"
 kubectl apply -f ./ci/artifacts/csi-storageclass.yaml
 echo "Deploying Busy-Box pod to use the cStor CSI volume..."

--- a/ci/sanity/sanity.sh
+++ b/ci/sanity/sanity.sh
@@ -130,7 +130,7 @@ IsPoolHealthy 30
 ## Once the pool is healthy verify whether cachefile stored in persistent path
 ## Get the CSPC name
 echo "Verifying whether pool cachefile is stored in persistent path"
-cspcName=$(kubectl get cspc -n openebs -o jsonpath={.items[0].metadata.name})
+cspcName=$(kubectl get cspc -n openebs -o=jsonpath={.items[0].metadata.name})
 if [ $? -ne 0 ]; then
     echo "Failed to get CSPC name"
     exit 1

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	github.com/openebs/api v1.10.0
+	github.com/openebs/api v1.10.1-0.20200519181449-902964f2beb0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	github.com/openebs/api v0.0.0-20200429072019-650209fba28b
+	github.com/openebs/api v1.10.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,7 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/cadvisor v0.35.0/go.mod h1:1nql6U13uTHaLYB8rLS5x9IJc2qT6Xd/Tr1sTX6NE48=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -278,6 +279,7 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.8 h1:QiWkFLKq0T7mpzwOTu6BzNDbfTE8OLrYhVKYMLF46Ok=
 github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -383,10 +385,10 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openebs/api v0.0.0-20200429072019-650209fba28b h1:XC6wCUascCjnEEstKkSFuEZB2YjTtm10Mx7SoRSHfhk=
-github.com/openebs/api v0.0.0-20200429072019-650209fba28b/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/openebs/api v1.10.0 h1:Jg+oN6g5McySACFkFyHqskomDgQJe7gFX35m0fkvRSU=
 github.com/openebs/api v1.10.0/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
+github.com/openebs/api v1.10.1-0.20200519181449-902964f2beb0 h1:8Cn6lH1T1RNwFa6t6OxCGkP1ZySNNrTU5UJpJHSSl60=
+github.com/openebs/api v1.10.1-0.20200519181449-902964f2beb0/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -592,6 +594,7 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -637,6 +640,7 @@ golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64bikrLBkAgPir1TNCj3Zs=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -661,6 +665,7 @@ google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -385,6 +385,8 @@ github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/openebs/api v0.0.0-20200429072019-650209fba28b h1:XC6wCUascCjnEEstKkSFuEZB2YjTtm10Mx7SoRSHfhk=
 github.com/openebs/api v0.0.0-20200429072019-650209fba28b/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
+github.com/openebs/api v1.10.0 h1:Jg+oN6g5McySACFkFyHqskomDgQJe7gFX35m0fkvRSU=
+github.com/openebs/api v1.10.0/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/pool/operations/import.go
+++ b/pkg/pool/operations/import.go
@@ -71,8 +71,23 @@ func (oc *OperationsConfig) Import(cspi *cstor.CStorPoolInstance) (bool, error) 
 	}
 
 	if !poolImported {
+		// Import the pool by reading from cache file
 		cmdOut, err = zfs.NewPoolImport().
 			WithCachefile(cacheFile).
+			WithProperty("cachefile", cacheFile).
+			WithPool(PoolName()).
+			Execute()
+		if err == nil {
+			poolImported = true
+		} else {
+			// TODO may be possible that there is no pool exists or no cache file exists
+			klog.Errorf("Failed to import pool by reading cache file: %s : %s", cmdOut, err.Error())
+		}
+	}
+
+	if !poolImported {
+		// Import the pool without cache file
+		cmdOut, err = zfs.NewPoolImport().
 			WithProperty("cachefile", cacheFile).
 			WithPool(PoolName()).
 			Execute()

--- a/pkg/pool/operations/import.go
+++ b/pkg/pool/operations/import.go
@@ -55,8 +55,10 @@ func (oc *OperationsConfig) Import(cspi *cstor.CStorPoolInstance) (bool, error) 
 	devID := pool.GetDevPathIfNotSlashDev(bdPath[0])
 	cacheFile := types.CStorPoolBasePath + types.CacheFileName
 	if len(devID) != 0 {
+		// Cachefile property takes more precedence over the directory
+		// for sparse based pools importing based on directory make more
+		// sense. As if we mention WithCacheFile then directory is not considered
 		cmdOut, err = zfs.NewPoolImport().
-			WithCachefile(cacheFile).
 			WithProperty("cachefile", cacheFile).
 			WithDirectory(devID).
 			WithPool(PoolName()).

--- a/vendor/github.com/openebs/api/pkg/apis/cstor/v1/cstorpoolcluster.go
+++ b/vendor/github.com/openebs/api/pkg/apis/cstor/v1/cstorpoolcluster.go
@@ -160,7 +160,7 @@ type CStorPoolClusterStatus struct {
 	HealthyInstances int32 `json:"healthyInstances"`
 
 	// Current state of CSPC.
-	Conditions []CStorPoolClusterCondition `json:conditions`
+	Conditions []CStorPoolClusterCondition `json:"conditions"`
 }
 
 type CSPCConditionType string

--- a/vendor/github.com/openebs/api/pkg/apis/openebs.io/v1alpha1/blockdeviceclaimbuilder.go
+++ b/vendor/github.com/openebs/api/pkg/apis/openebs.io/v1alpha1/blockdeviceclaimbuilder.go
@@ -29,6 +29,10 @@ const (
 	StoragePoolKindCSPC = "CStorPoolCluster"
 	// APIVersion holds the value of OpenEBS version
 	APIVersion = "openebs.io/v1alpha1"
+
+	// bdTagKey defines the label selector key
+	// used for grouping block devices using a tag.
+	bdTagKey = "openebs.io/block-device-tag"
 )
 
 func NewBlockDeviceClaim() *BlockDeviceClaim {
@@ -141,6 +145,23 @@ func (bdc *BlockDeviceClaim) WithBlockVolumeMode(mode corev1.PersistentVolumeMod
 	if mode == corev1.PersistentVolumeBlock {
 		bdc.Spec.Details.BlockVolumeMode = VolumeModeBlock
 	}
+	return bdc
+}
+
+// WithBlockDeviceTag appends (or creates) the BDC Label Selector
+// by setting the provided value to the fixed key
+// openebs.io/block-device-tag
+// This will enable the NDM to pick only devices that
+// match the node (hostname) and block device tag value.
+func (bdc *BlockDeviceClaim) WithBlockDeviceTag(bdTagValue string) *BlockDeviceClaim  {
+	if bdc.Spec.Selector == nil {
+		bdc.Spec.Selector = &metav1.LabelSelector{}
+	}
+	if bdc.Spec.Selector.MatchLabels == nil {
+		bdc.Spec.Selector.MatchLabels = map[string]string{}
+	}
+
+	bdc.Spec.Selector.MatchLabels[bdTagKey] = bdTagValue
 	return bdc
 }
 

--- a/vendor/github.com/openebs/api/pkg/apis/types/types.go
+++ b/vendor/github.com/openebs/api/pkg/apis/types/types.go
@@ -81,7 +81,7 @@ const (
 )
 
 const (
-	CStorPoolBasePath = "/var/openebs/cstor-pool"
+	CStorPoolBasePath = "/var/openebs/cstor-pool/"
 	CacheFileName     = "pool.cache"
 )
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,7 @@ github.com/json-iterator/go
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/openebs/api v0.0.0-20200429072019-650209fba28b
+# github.com/openebs/api v1.10.1-0.20200519181449-902964f2beb0
 github.com/openebs/api/pkg/apis/cstor
 github.com/openebs/api/pkg/apis/cstor/v1
 github.com/openebs/api/pkg/apis/openebs.io


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>
This PR will try to import the pool without the cache file as a last option. 
It will import the pool in the following ways:
- Import the pool using cachefile  `zpool import -c cachefile=<cache_file> -o cachefile=<cache_file> <pool_name>`
- Import the pool without using cachefile:
  1. If it is sparse based pool then command will be `zpool import  -o cachefile=<cache_file> -d <parent_directory_of_sparse_file> <pool_name>`
  2. If it device based pool then command will be `zpool import -o cachefile=<cache_file> <pool_name>`(By default it will scan /dev directory).

**NOTE**:
- Due to bug in persisting the cachefile i.e cachefile is not stored in the persistent path because of this when pool pod got restarted then the pool will not be imported to fix this added the code to import without cachefile.