### PR TITLE
fix(webhook): fix blockdevice replacement validation

### DIFF
--- a/pkg/webhook/cspc_operations.go
+++ b/pkg/webhook/cspc_operations.go
@@ -649,10 +649,10 @@ func (pOps *PoolOperations) ArePoolSpecChangesValid(oldPoolSpec, newPoolSpec *cs
 	}
 	for _, v := range commonRaidGroups {
 		rgType := v.rgType
-		for _, oldRg := range v.oldRaidGroups {
-			oldRg := oldRg
-			for _, newRg := range v.newRaidGroups {
-				newRg := newRg
+		for index, _ := range v.oldRaidGroups {
+			oldRg := v.oldRaidGroups[index]
+			for _, _ = range v.newRaidGroups {
+				newRg := v.newRaidGroups[index]
 				if err = validateRaidGroupChanges(&oldRg, &newRg, rgType); err != nil {
 					return false, fmt.Sprintf("raid group validation failed: %v", err)
 				}

--- a/pkg/webhook/cspc_test.go
+++ b/pkg/webhook/cspc_test.go
@@ -23,13 +23,16 @@ import (
 
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	openebsapi "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/api/pkg/apis/types"
 	clientset "github.com/openebs/api/pkg/client/clientset/versioned"
 	"github.com/pkg/errors"
 	"k8s.io/api/admission/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	kubeFakeClient "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/klog"
 )
 
 func TestValidateSpecChanges(t *testing.T) {
@@ -107,6 +110,17 @@ func fakeGetCSPCError(name, namespace string, clientset clientset.Interface) (*c
 	return nil, errors.Errorf("fake error")
 }
 
+func (f *fixture) fakeNodeCreator(nodeCount int) {
+	for i := 1; i <= nodeCount; i++ {
+		name := "worker-" + strconv.Itoa(i)
+		nodeObj := getfakeNodeSpec(name)
+		_, err := f.wh.kubeClient.CoreV1().Nodes().Create(nodeObj)
+		if err != nil {
+			klog.Error(err)
+		}
+	}
+}
+
 func getfakeNodeSpec(name string) *corev1.Node {
 	return &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -122,9 +136,122 @@ func getfakeNodeSpec(name string) *corev1.Node {
 	}
 }
 
-func getfakeBDs(nodeName string) []*openebsapi.BlockDevice {
+func (f *fixture) fakeBlockDeviceCreator(totalDisk, totalNodeCount int) {
+	// Create some fake block device objects over nodes.
+	var key, diskLabel string
+
+	diskCountPerNode := totalDisk / totalNodeCount
+	// nodeIdentifer will help in naming a node and attaching multiple disks to a single node.
+	nodeIdentifer := 1
+	for diskListIndex := 1; diskListIndex <= totalDisk; diskListIndex++ {
+		diskIdentifier := strconv.Itoa(diskListIndex)
+
+		if diskListIndex%diskCountPerNode == 0 {
+			nodeIdentifer++
+		}
+
+		key = "ndm.io/blockdevice-type"
+		diskLabel = "blockdevice"
+		bdObj := &openebsapi.BlockDevice{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "BlockDevices",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "blockdevice-" + diskIdentifier,
+				UID:  k8stypes.UID("bdtest" + strconv.Itoa(nodeIdentifer) + diskIdentifier),
+				Labels: map[string]string{
+					"kubernetes.io/hostname": "worker-" + strconv.Itoa(nodeIdentifer),
+					key:                      diskLabel,
+				},
+			},
+			Spec: openebsapi.DeviceSpec{
+				Details: openebsapi.DeviceDetails{
+					DeviceType: "disk",
+				},
+				Partitioned: "NO",
+				Capacity: openebsapi.DeviceCapacity{
+					Storage: 120000000000,
+				},
+				NodeAttributes: openebsapi.NodeAttribute{
+					NodeName: "worker-" + strconv.Itoa(nodeIdentifer),
+				},
+			},
+			Status: openebsapi.DeviceStatus{
+				State: openebsapi.BlockDeviceActive,
+			},
+		}
+		_, err := f.wh.clientset.OpenebsV1alpha1().BlockDevices("openebs").Create(bdObj)
+		if err != nil {
+			klog.Error(err)
+		}
+
+	}
+}
+
+func (f *fixture) markBlockDeviceWithReplacementMarks(
+	markBDUnderReplacement map[string]string, cspcName string) error {
+	for newBD, oldBD := range markBDUnderReplacement {
+		bdObj, err := f.wh.clientset.
+			OpenebsV1alpha1().
+			BlockDevices("openebs").
+			Get(newBD, metav1.GetOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to get blockdevice %s", newBD)
+		}
+		hostName := bdObj.Labels["kubernetes.io/hostname"]
+		// Build blockdeviceclaim to claim the blockdevice
+		bdcObj := &openebsapi.BlockDeviceClaim{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "BlockDeviceClaim",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "blockdeviceclaim-" + newBD,
+				UID:       k8stypes.UID("bdctest" + hostName + bdObj.Name),
+				Namespace: "openebs",
+				Labels: map[string]string{
+					string(types.CStorPoolClusterLabelKey): cspcName,
+				},
+				Annotations: map[string]string{
+					types.PredecessorBDLabelKey: oldBD,
+				},
+			},
+			Spec: openebsapi.DeviceClaimSpec{
+				BlockDeviceName: newBD,
+			},
+			Status: openebsapi.DeviceClaimStatus{
+				Phase: openebsapi.BlockDeviceClaimStatusDone,
+			},
+		}
+		// Create blockdeviceclaim for blockdevice
+		_, err = f.wh.clientset.
+			OpenebsV1alpha1().
+			BlockDeviceClaims("openebs").
+			Create(bdcObj)
+		if err != nil {
+			return errors.Wrapf(err, "failed to create claim for blockdevice %s", newBD)
+		}
+		// Bound blockdevice with blockdeviceclaim
+		bdObj.Status.ClaimState = openebsapi.BlockDeviceClaimed
+		bdObj.Spec.ClaimRef = &corev1.ObjectReference{
+			Kind:      "BlockDeviceClaim",
+			Name:      bdcObj.Name,
+			Namespace: "openebs",
+		}
+		_, err = f.wh.clientset.
+			OpenebsV1alpha1().
+			BlockDevices("openebs").
+			Update(bdObj)
+		if err != nil {
+			return errors.Wrapf(err, "failed to mark blockdevice %s as claimed", newBD)
+		}
+	}
+	return nil
+}
+
+// TODO: remove below function
+func getfakeBDs(nodeName string, diskCount int) []*openebsapi.BlockDevice {
 	bds := []*openebsapi.BlockDevice{}
-	for i := 1; i < 7; i++ {
+	for i := 1; i <= diskCount; i++ {
 		bd := &openebsapi.BlockDevice{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "blockdevice-" + strconv.Itoa(i),
@@ -498,7 +625,7 @@ func TestValidateCSPCUpdateRequest(t *testing.T) {
 			_, err := f.wh.kubeClient.CoreV1().Nodes().
 				Create(getfakeNodeSpec("node1"))
 			// Create fake bd objects in etcd
-			for _, bd := range getfakeBDs("node1") {
+			for _, bd := range getfakeBDs("node1", 7) {
 				_, err = f.wh.clientset.OpenebsV1alpha1().
 					BlockDevices(bd.Namespace).
 					Create(bd)
@@ -527,4 +654,294 @@ func TestValidateCSPCUpdateRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBlockDeviceReplacement(t *testing.T) {
+	f := newFixture().withOpenebsObjects().withKubeObjects()
+	f.fakeNodeCreator(3)
+	// Each node will have 20 blockdevices
+	f.fakeBlockDeviceCreator(60, 3)
+	tests := map[string]struct {
+		// existingObj is object existing in etcd via fake client
+		existingObj                      *cstor.CStorPoolCluster
+		requestedObj                     *cstor.CStorPoolCluster
+		markBlockDevicesUnderReplacement map[string]string
+		expectedRsp                      bool
+		getCSPCObj                       getCSPC
+	}{
+		"Replacement triggered on stripe pool": {
+			existingObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-stripe").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("stripe")).
+						WithDataRaidGroups(*cstor.NewRaidGroup().
+							WithCStorPoolInstanceBlockDevices(*cstor.NewCStorPoolInstanceBlockDevice().
+								WithName("blockdevice-1"))),
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-2"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("stripe")).
+						WithDataRaidGroups(*cstor.NewRaidGroup().
+							WithCStorPoolInstanceBlockDevices(*cstor.NewCStorPoolInstanceBlockDevice().
+								WithName("blockdevice-21"))),
+				),
+			requestedObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-stripe").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("stripe")).
+						WithDataRaidGroups(*cstor.NewRaidGroup().
+							WithCStorPoolInstanceBlockDevices(*cstor.NewCStorPoolInstanceBlockDevice().
+								WithName("blockdevice-1"))),
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-2"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("stripe")).
+						WithDataRaidGroups(*cstor.NewRaidGroup().
+							WithCStorPoolInstanceBlockDevices(*cstor.NewCStorPoolInstanceBlockDevice().
+								WithName("blockdevice-22"))),
+				),
+			expectedRsp: false,
+			getCSPCObj:  getCSPCObject,
+		},
+		"Replacement triggered on mirror pool": {
+			existingObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-mirror").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("mirror")).
+						WithDataRaidGroups(*cstor.NewRaidGroup().
+							WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-2"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-3"),
+							),
+						),
+				),
+			requestedObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-mirror").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("mirror")).
+						WithDataRaidGroups(*cstor.NewRaidGroup().
+							WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-4"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-3"),
+							),
+						),
+				),
+			expectedRsp: true,
+			getCSPCObj:  getCSPCObject,
+		},
+		"Replacement triggered on mirror pool which has two raid groups": {
+			existingObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-mirror-2").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("mirror")).
+						WithDataRaidGroups(
+							*cstor.NewRaidGroup().WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-5"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-6"),
+							),
+							*cstor.NewRaidGroup().WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-7"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-8"),
+							),
+						),
+				),
+			requestedObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-mirror-2").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("mirror")).
+						WithDataRaidGroups(
+							*cstor.NewRaidGroup().WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-5"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-9"),
+							),
+							*cstor.NewRaidGroup().WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-10"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-8"),
+							),
+						),
+				),
+			expectedRsp: true,
+			getCSPCObj:  getCSPCObject,
+		},
+		"Replacement triggered on RAIDZ pool": {
+			existingObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-raidz").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("raidz")).
+						WithDataRaidGroups(
+							*cstor.NewRaidGroup().WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-11"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-12"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-13"),
+							),
+						),
+				),
+			requestedObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-raidz").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("raidz")).
+						WithDataRaidGroups(
+							*cstor.NewRaidGroup().WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-14"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-12"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-13"),
+							),
+						),
+				),
+			expectedRsp: true,
+			getCSPCObj:  getCSPCObject,
+		},
+		"Invalid Replacement triggered on RAIDZ pool": {
+			existingObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-raidz-2").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-2"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("raidz")).
+						WithDataRaidGroups(
+							*cstor.NewRaidGroup().WithCStorPoolInstanceBlockDevices(
+								// Until claims are created there should not be any problem in using same blockdevices
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-22"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-23"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-24"),
+							),
+						),
+				),
+			requestedObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-raidz-2").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("raidz")).
+						WithDataRaidGroups(
+							*cstor.NewRaidGroup().WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-25"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-26"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-24"),
+							),
+						),
+				),
+			expectedRsp: false,
+			getCSPCObj:  getCSPCObject,
+		},
+		"Replace blockdevice in raidgroup which is currently undergoing replacement": {
+			existingObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-mirror-3").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-2"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("mirror")).
+						WithDataRaidGroups(*cstor.NewRaidGroup().
+							WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-27"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-28"),
+							),
+						),
+				),
+			requestedObj: cstor.NewCStorPoolCluster().
+				WithName("cspc-foo-mirror-3").
+				WithNamespace("openebs").
+				WithPoolSpecs(
+					*cstor.NewPoolSpec().
+						WithNodeSelector(map[string]string{types.HostNameLabelKey: "worker-1"}).
+						WithPoolConfig(*cstor.NewPoolConfig().
+							WithDataRaidGroupType("mirror")).
+						WithDataRaidGroups(*cstor.NewRaidGroup().
+							WithCStorPoolInstanceBlockDevices(
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-27"),
+								*cstor.NewCStorPoolInstanceBlockDevice().WithName("blockdevice-29"),
+							),
+						),
+				),
+			markBlockDevicesUnderReplacement: map[string]string{
+				"blockdevice-27": "blockdevice-24",
+			},
+			expectedRsp: false,
+			getCSPCObj:  getCSPCObject,
+		},
+	}
+	// Set OPENEBS_NAMESPACE env
+	os.Setenv("OPENEBS_NAMESPACE", "openebs")
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			ar := &v1beta1.AdmissionRequest{
+				Operation: v1beta1.Create,
+				Object: runtime.RawExtension{
+					Raw: serialize(test.requestedObj),
+				},
+			}
+			// Create fake object in etcd
+			_, err := f.wh.clientset.CstorV1().
+				CStorPoolClusters(test.existingObj.Namespace).
+				Create(test.existingObj)
+			if err != nil {
+				t.Fatalf(
+					"failed to create fake CSPC %s Object in Namespace %s error: %v",
+					test.existingObj.Name,
+					test.existingObj.Namespace,
+					err,
+				)
+			}
+			if test.markBlockDevicesUnderReplacement != nil {
+				if err = f.markBlockDeviceWithReplacementMarks(
+					test.markBlockDevicesUnderReplacement, test.existingObj.Name); err != nil {
+					t.Fatalf(
+						"failed to mark blockdevice with replacement in progress error: %v",
+						err,
+					)
+				}
+			}
+			resp := f.wh.validateCSPCUpdateRequest(ar, test.getCSPCObj)
+			if resp.Allowed != test.expectedRsp {
+				t.Errorf(
+					"%s test case failed expected response: %t but got %t error: %s",
+					name,
+					test.expectedRsp,
+					resp.Allowed,
+					resp.Result.Message,
+				)
+			}
+		})
+	}
+	// Set OPENEBS_NAMESPACE env
+	os.Unsetenv("OPENEBS_NAMESPACE")
 }


### PR DESCRIPTION
This PR fixes the blockdevice replacement validations performed by the CStor admission server.

**Old RaidGroups**: RaidGroups of CSPC present in etcd.
**New RaidGroups**: RaidGroups of newly requested CSPC for updates.

**Before bug fix**:
- We are forming an index mapping(two different RaidGroup lists let us say rgList1 and rgList2. In these lists rgList1 of 0th index and rgList2 of 0th index contains the same RaidGroup[Marked RaidGroup as common which has at least one common blockdevice]) between old and new RaidGroups.
- Iterating over rgList1 and rgList2(as an outer and inner loop) and checking whether it is a case of replacement. If it a case of replacement then further [validations](https://github.com/openebs/openebs/blob/master/contribute/design/1.x/cstor-operator/doc.md#disk-replacement) were made on the request.
- So when iterating over the second index on rgList1(outer loop) in the inner loop again starts from 0th index which leads to wrong validations.

**How This PR helps in bug fix**:
- Instead of iterating over two rgList1 and rgList2 iterate over only one list since both are already mapped with an index so it will have all common RaidGroups(old & new). For each iteration corresponding index will be picked and validated.

Error facing in replacing blockdevices other that first RaidGroup
```sh
error: cstorpoolclusters.cstor.openebs.io "cspc-stripe" could not be patched: admission webhook "admission-webhook.cstor.openebs.io" denied the request: invalid cspc specification: cannot replace more than one blockdevice in a raid group
You can run `kubectl replace -f /tmp/kubectl-edit-isowr.yaml` to try this update again.
```


Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>