### PR TITLE
refactor(build): remove hardcoded docker org (#84)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,11 +80,11 @@ endif
 export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
 
 # Specify the name of cstor-base image
-CSTOR_BASE_IMAGE= openebs/cstor-base:${BASE_TAG}
+CSTOR_BASE_IMAGE= ${IMAGE_ORG}/cstor-base:${BASE_TAG}
 export CSTOR_BASE_IMAGE
 
 ifeq (${CSTOR_BASE_IMAGE_ARM64}, )
-  CSTOR_BASE_IMAGE_ARM64= openebs/cstor-base-arm64:${BASE_TAG}
+  CSTOR_BASE_IMAGE_ARM64= ${IMAGE_ORG}/cstor-base-arm64:${BASE_TAG}
   export CSTOR_BASE_IMAGE_ARM64
 endif
 
@@ -202,8 +202,8 @@ all.amd64: cspc-operator-image.amd64 pool-manager-image.amd64 cstor-webhook-imag
 # Push images
 .PHONY: deploy-images
 deploy-images:
-	@DIMAGE=openebs/cvc-operator-${XC_ARCH} ./build/push;
-	@DIMAGE=openebs/cspc-operator-${XC_ARCH} ./build/push;
-	@DIMAGE=openebs/cstor-volume-manager-${XC_ARCH} ./build/push;
-	@DIMAGE=openebs/cstor-pool-manager-${XC_ARCH} ./build/push;
-	@DIMAGE=openebs/cstor-webhook-${XC_ARCH} ./build/push;
+	@DIMAGE=${IMAGE_ORG}/cvc-operator-${XC_ARCH} ./build/push;
+	@DIMAGE=${IMAGE_ORG}/cspc-operator-${XC_ARCH} ./build/push;
+	@DIMAGE=${IMAGE_ORG}/cstor-volume-manager-${XC_ARCH} ./build/push;
+	@DIMAGE=${IMAGE_ORG}/cstor-pool-manager-${XC_ARCH} ./build/push;
+	@DIMAGE=${IMAGE_ORG}/cstor-webhook-${XC_ARCH} ./build/push;

--- a/build/cspc-operator/Dockerfile
+++ b/build/cspc-operator/Dockerfile
@@ -23,8 +23,6 @@ ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.name="cspc-operator"
 LABEL org.label-schema.description="CSPC Operator for OpenEBS cStor engine"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL

--- a/build/cstor-webhook/Dockerfile
+++ b/build/cstor-webhook/Dockerfile
@@ -14,8 +14,6 @@ ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.name="cstor-webhook"
 LABEL org.label-schema.description="Webhook admission server for cStor"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL

--- a/build/cvc-operator/Dockerfile
+++ b/build/cvc-operator/Dockerfile
@@ -19,8 +19,6 @@ ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.name="cvc-operator"
 LABEL org.label-schema.description="Operator for OpenEBS cStor csi volumes"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL

--- a/build/cvc-operator/Dockerfile.arm64
+++ b/build/cvc-operator/Dockerfile.arm64
@@ -22,8 +22,6 @@ ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.name="cvc-operator"
 LABEL org.label-schema.description="Operator for OpenEBS cStor csi volumes"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL

--- a/build/pool-manager/Dockerfile
+++ b/build/pool-manager/Dockerfile
@@ -25,8 +25,6 @@ ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.name="cstor-pool-manager"
 LABEL org.label-schema.description="Pool manager for cStor pool"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL

--- a/build/volume-manager/Dockerfile
+++ b/build/volume-manager/Dockerfile
@@ -21,8 +21,6 @@ ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.name="cstor-volume-manager"
 LABEL org.label-schema.description="Volume manager for cStor volumes"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$BUILD_DATE
 LABEL org.label-schema.build-date=$DBUILD_DATE

--- a/build/volume-manager/Dockerfile.arm64
+++ b/build/volume-manager/Dockerfile.arm64
@@ -25,8 +25,6 @@ ARG DBUILD_SITE_URL
 
 LABEL org.label-schema.name="cstor-volume-mgmt"
 LABEL org.label-schema.description="Volume manager for cStor volumes"
-LABEL org.label-schema.url="http://www.openebs.io/"
-LABEL org.label-schema.vcs-url="https://github.com/openebs/cstor-operators"
 LABEL org.label-schema.schema-version="1.0"
 LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL


### PR DESCRIPTION
The forked repo might push the images to a
custom org that is set via IMAGE_ORG env.

Removed hardcoded references to org as 'openebs'

Also, removed duplicate docker labels.

Signed-off-by: kmova <kiran.mova@mayadata.io>
(cherry picked from commit 3bfd267b44b03830ede065a9b31cd31079d4c5e9)