### PR TITLE
feat(backup-controller): add suport for backup controller

### DIFF
--- a/cmd/pool-manager/app/start.go
+++ b/cmd/pool-manager/app/start.go
@@ -23,12 +23,11 @@ import (
 	"sync"
 	"time"
 
-	restorecontroller "github.com/openebs/cstor-operators/pkg/controllers/restore-controller"
-
 	backupcontroller "github.com/openebs/cstor-operators/pkg/controllers/backup-controller"
 	"github.com/openebs/cstor-operators/pkg/controllers/common"
 	cspicontroller "github.com/openebs/cstor-operators/pkg/controllers/cspi-controller"
 	replicacontroller "github.com/openebs/cstor-operators/pkg/controllers/replica-controller"
+	restorecontroller "github.com/openebs/cstor-operators/pkg/controllers/restore-controller"
 	"github.com/openebs/cstor-operators/pkg/pool"
 	"github.com/pkg/errors"
 	"k8s.io/klog"

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	github.com/openebs/api v1.10.0-RC1.0.20200528063752-522f45d17d59
+	github.com/openebs/api v1.10.0-RC1.0.20200602151240-2b7d2bdbe1ef
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,8 @@ github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/openebs/api v1.10.0-RC1.0.20200528063752-522f45d17d59 h1:9fZ9KGtlStVxI/dQUmNhCnHt6gn8cuuCBo7kpTI+ZdE=
 github.com/openebs/api v1.10.0-RC1.0.20200528063752-522f45d17d59/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
+github.com/openebs/api v1.10.0-RC1.0.20200602151240-2b7d2bdbe1ef h1:p66ZTG26pNr7TIxOMLmXvJcKjmIxIa+xsQ5Xw0hhJA4=
+github.com/openebs/api v1.10.0-RC1.0.20200602151240-2b7d2bdbe1ef/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/controllers/backup-controller/controller.go
+++ b/pkg/controllers/backup-controller/controller.go
@@ -257,7 +257,7 @@ func (c *BackupController) handleBKPUpdateEvent(oldbkp, newbkp *apis.CStorBackup
 		klog.Infof("CStorBackup Destroy event : %v, %v", newbkp.ObjectMeta.Name, string(newbkp.ObjectMeta.UID))
 		c.recorder.Event(newbkp, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageDestroySynced))
 	} else {
-		klog.Infof("CStorBackup Modify event : %v, %v", newbkp.ObjectMeta.Name, string(newbkp.ObjectMeta.UID))
+		klog.V(4).Infof("CStorBackup Modify event : %v, %v", newbkp.ObjectMeta.Name, string(newbkp.ObjectMeta.UID))
 		q.Operation = common.QOpSync
 		c.recorder.Event(newbkp, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageModifySynced))
 	}

--- a/pkg/controllers/backup-controller/controller.go
+++ b/pkg/controllers/backup-controller/controller.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backupcontroller
+
+import (
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
+
+	"github.com/openebs/cstor-operators/pkg/controllers/common"
+
+	apis "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
+	openebstypes "github.com/openebs/api/pkg/apis/types"
+
+	clientset "github.com/openebs/api/pkg/client/clientset/versioned"
+	openebsScheme "github.com/openebs/api/pkg/client/clientset/versioned/scheme"
+	informers "github.com/openebs/api/pkg/client/informers/externalversions"
+)
+
+var (
+	backupControllerName = "CStorBackup"
+	// OpenEBSIOCSPIID is the environment variable specified in pod.
+	// It holds the UID of the CSPI
+	OpenEBSIOCSPIID string = "OPENEBS_IO_CSPI_ID"
+)
+
+// BackupController is the controller implementation for CStorBackup resources.
+type BackupController struct {
+	// kubeclientset is a standard kubernetes clientset.
+	kubeclientset kubernetes.Interface
+
+	// clientset is a openebs custom resource package generated for custom API group.
+	clientset clientset.Interface
+
+	// BackupSynced is used for caches sync to get populated
+	BackupSynced cache.InformerSynced
+
+	// workqueue is a rate limited work queue. This is used to queue work to be
+	// processed instead of performing it as soon as a change happens. This
+	// means we can ensure we only process a fixed amount of resources at a
+	// time, and makes it easy to ensure we are never processing the same item
+	// simultaneously in two different workers.
+	workqueue workqueue.RateLimitingInterface
+	// recorder is an event recorder for recording Event resources to the
+	// Kubernetes API.
+	recorder record.EventRecorder
+}
+
+// NewCStorBackupController returns a new instance of cStor Backup controller
+func NewCStorBackupController(
+	kubeclientset kubernetes.Interface,
+	clientset clientset.Interface,
+	kubeInformerFactory kubeinformers.SharedInformerFactory,
+	cStorInformerFactory informers.SharedInformerFactory) *BackupController {
+
+	// obtain references to shared index informers for the CStorBackup resources.
+	BackupInformer := cStorInformerFactory.Openebs().V1alpha1().CStorBackups()
+
+	err := openebsScheme.AddToScheme(scheme.Scheme)
+	if err != nil {
+		klog.Fatalf("Error adding scheme to openebs scheme: %s", err.Error())
+		return nil
+	}
+
+	// Create event broadcaster
+	// Add backup-cstor-controller types to the default Kubernetes Scheme so Events can be
+	// logged for backup-cstor-controller types.
+	klog.V(4).Info("Creating backup event broadcaster")
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(klog.Infof)
+
+	// StartEventWatcher starts sending events received from this EventBroadcaster to the given
+	// event handler function. The return value can be ignored or used to stop recording, if
+	// desired. Events("") denotes empty namespace
+	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: kubeclientset.CoreV1().Events("")})
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: backupControllerName})
+
+	controller := &BackupController{
+		kubeclientset: kubeclientset,
+		clientset:     clientset,
+		BackupSynced:  BackupInformer.Informer().HasSynced,
+		workqueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CStorBackup"),
+		recorder:      recorder,
+	}
+
+	klog.Info("Setting up event handlers for backup")
+
+	// Clean any pending backup for this cstor pool
+	controller.cleanupOldBackup()
+
+	// Instantiating QueueLoad before entering workqueue.
+	q := common.QueueLoad{}
+
+	// Set up an event handler for when CStorBackup resources change.
+	BackupInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			// Note: AddFunc is called when a new object comes into etcd
+			// Note : In case controller reboots and existing object in etcd can cause delivery of
+			// add event when the controller comes again. Be careful in this part and handle accordingly.
+			bkp := obj.(*apis.CStorBackup)
+
+			if !IsRightCStorPoolInstanceMgmt(bkp) {
+				return
+			}
+			controller.handleBKPAddEvent(bkp, &q)
+		},
+		UpdateFunc: func(oldVar, newVar interface{}) {
+			// Note : UpdateFunc is called in following three cases:
+			// 1. When object is updated/patched i.e. Resource version of object changes.
+			// 2. When object is deleted i.e. the deletion timestamp of object is set.
+			// 3. After every resync interval.
+			newbkp := newVar.(*apis.CStorBackup)
+			oldbkp := oldVar.(*apis.CStorBackup)
+
+			if !IsRightCStorPoolInstanceMgmt(newbkp) {
+				return
+			}
+
+			controller.handleBKPUpdateEvent(oldbkp, newbkp, &q)
+		},
+		DeleteFunc: func(obj interface{}) {
+			bkp := obj.(*apis.CStorBackup)
+			if !IsRightCStorPoolInstanceMgmt(bkp) {
+				return
+			}
+			klog.Infof("CStorBackup Resource delete event: %v, %v", bkp.ObjectMeta.Name, string(bkp.ObjectMeta.UID))
+		},
+	})
+	return controller
+}
+
+// enqueueCStorBackup takes a CStorBackup resource and converts it into a namespace/name
+// string which is then put onto the work queue. This method should *not* be
+// passed resources of any type other than CStorBackup.
+func (c *BackupController) enqueueCStorBackup(obj *apis.CStorBackup, q common.QueueLoad) {
+	var key string
+	var err error
+	if key, err = cache.MetaNamespaceKeyFunc(obj); err != nil {
+		runtime.HandleError(err)
+		return
+	}
+	q.Key = key
+	c.workqueue.AddRateLimited(q)
+}
+
+// IsRightCStorPoolInstanceMgmt is to check if the backup request is for this cstor-pool or not.
+func IsRightCStorPoolInstanceMgmt(bkp *apis.CStorBackup) bool {
+	if os.Getenv(OpenEBSIOCSPIID) ==
+		bkp.GetLabels()[openebstypes.CStorPoolInstanceUIDLabelKey] {
+		return true
+	}
+	return false
+}
+
+// cleanupOldBackup set fail status to old pending backup
+func (c *BackupController) cleanupOldBackup() {
+	bkplabel := openebstypes.CStorPoolInstanceUIDLabelKey + "=" + os.Getenv(OpenEBSIOCSPIID)
+	bkplistop := metav1.ListOptions{
+		LabelSelector: bkplabel,
+	}
+
+	bkplist, err := c.clientset.OpenebsV1alpha1().CStorBackups(metav1.NamespaceAll).List(bkplistop)
+	if err != nil {
+		return
+	}
+
+	for _, bkp := range bkplist.Items {
+		switch bkp.Status {
+		case apis.BKPCStorStatusInProgress:
+			//Backup was in in-progress state
+			laststate := findLastBackupStat(c.clientset, bkp)
+			updateBackupStatus(c.clientset, bkp, laststate)
+		case apis.BKPCStorStatusDone:
+			continue
+		default:
+			//Set backup status as failed
+			updateBackupStatus(c.clientset, bkp, apis.BKPCStorStatusFailed)
+		}
+	}
+}
+
+// updateBackupStatus will update the backup status to given status
+func updateBackupStatus(clientset clientset.Interface, bkp apis.CStorBackup, status apis.CStorBackupStatus) {
+	bkp.Status = status
+
+	_, err := clientset.OpenebsV1alpha1().CStorBackups(bkp.Namespace).Update(&bkp)
+	if err != nil {
+		klog.Errorf("Failed to update backup(%s) status(%s)", status, bkp.Name)
+		return
+	}
+}
+
+// findLastBackupStat will find the status of backup from last completed-backup
+func findLastBackupStat(clientset clientset.Interface, bkp apis.CStorBackup) apis.CStorBackupStatus {
+	lastbkpname := bkp.Spec.BackupName + "-" + bkp.Spec.VolumeName
+
+	lastbkp, err := clientset.OpenebsV1alpha1().
+		CStorCompletedBackups(bkp.Namespace).
+		Get(lastbkpname, metav1.GetOptions{})
+	if err != nil {
+		// Unable to fetch the last backup, so we will return fail state
+		klog.Errorf("Failed to fetch last completed backup:%s error:%s", lastbkpname, err.Error())
+		return apis.BKPCStorStatusFailed
+	}
+
+	// let's check if snapname matches with current snapshot name
+	if bkp.Spec.SnapName == lastbkp.Spec.SnapName || bkp.Spec.SnapName == lastbkp.Spec.PrevSnapName {
+		return apis.BKPCStorStatusDone
+	}
+
+	// lastbackup snap/prevsnap doesn't match with bkp snapname
+	return apis.BKPCStorStatusFailed
+}
+
+// handleBKPAddEvent is to handle add operation of backup controller
+func (c *BackupController) handleBKPAddEvent(bkp *apis.CStorBackup, q *common.QueueLoad) {
+	q.Operation = common.QOpAdd
+	klog.Infof("CStorBackup event added: %v, %v", bkp.ObjectMeta.Name, string(bkp.ObjectMeta.UID))
+	c.recorder.Event(bkp, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageCreateSynced))
+	c.enqueueCStorBackup(bkp, *q)
+}
+
+// handleBKPUpdateEvent is to handle add operation of backup controller
+func (c *BackupController) handleBKPUpdateEvent(oldbkp, newbkp *apis.CStorBackup, q *common.QueueLoad) {
+	klog.V(2).Infof("Received Update for backup:%s", oldbkp.ObjectMeta.Name)
+
+	if newbkp.ResourceVersion == oldbkp.ResourceVersion {
+		return
+	}
+
+	if IsDestroyEvent(newbkp) {
+		q.Operation = common.QOpDestroy
+		klog.Infof("CStorBackup Destroy event : %v, %v", newbkp.ObjectMeta.Name, string(newbkp.ObjectMeta.UID))
+		c.recorder.Event(newbkp, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageDestroySynced))
+	} else {
+		klog.Infof("CStorBackup Modify event : %v, %v", newbkp.ObjectMeta.Name, string(newbkp.ObjectMeta.UID))
+		q.Operation = common.QOpSync
+		c.recorder.Event(newbkp, corev1.EventTypeNormal, string(common.SuccessSynced), string(common.MessageModifySynced))
+	}
+	c.enqueueCStorBackup(newbkp, *q)
+}

--- a/pkg/controllers/backup-controller/controller_test.go
+++ b/pkg/controllers/backup-controller/controller_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package backupcontroller
+
+import (
+	"testing"
+	"time"
+
+	openebsFakeClientset "github.com/openebs/api/pkg/client/clientset/versioned/fake"
+	openebsinformers "github.com/openebs/api/pkg/client/informers/externalversions"
+
+	kubeinformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// TestNewCStorBackupController tests if the kubernetes and openebs
+// configs are present in cstor backup instance.
+func TestNewCStorBackupController(t *testing.T) {
+	fakeKubeClient := fake.NewSimpleClientset()
+	fakeOpenebsClient := openebsFakeClientset.NewSimpleClientset()
+
+	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(fakeKubeClient, time.Second*30)
+	openebsInformerFactory := openebsinformers.NewSharedInformerFactory(fakeOpenebsClient, time.Second*30)
+
+	// Instantiate the cStor backup controllers.
+	backupController := NewCStorBackupController(fakeKubeClient, fakeOpenebsClient, kubeInformerFactory,
+		openebsInformerFactory)
+
+	if backupController.kubeclientset != fakeKubeClient {
+		t.Fatalf("Pool controller object's kubeclientset mismatch")
+	}
+	if backupController.clientset != fakeOpenebsClient {
+		t.Fatalf("Pool controller object's OpenebsClientset mismatch")
+	}
+}

--- a/pkg/controllers/backup-controller/handler.go
+++ b/pkg/controllers/backup-controller/handler.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2018 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backupcontroller
+
+import (
+	"fmt"
+
+	apis "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
+	"github.com/openebs/cstor-operators/pkg/controllers/common"
+	"github.com/openebs/cstor-operators/pkg/volumereplica"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// syncHandler compares the actual state with the desired, and attempts to
+// converge the two. It then updates the Status block of the CStorBackup resource
+// with the current status of the resource.
+func (c *BackupController) syncHandler(key string, operation common.QueueOperation) error {
+	bkp, err := c.getCStorBackupResource(key)
+	if err != nil {
+		return err
+	}
+	if bkp == nil {
+		return fmt.Errorf("cannot retrieve CStorBackup %q", key)
+	}
+	if IsDoneStatus(bkp) || IsFailedStatus(bkp) {
+		return nil
+	}
+
+	status, err := c.eventHandler(operation, bkp)
+	if err != nil {
+		klog.Errorf(err.Error())
+		bkp.Status = apis.BKPCStorStatusFailed
+	} else {
+		bkp.Status = apis.CStorBackupStatus(status)
+	}
+	if status == "" {
+		return nil
+	}
+
+	nbkp, err := c.clientset.OpenebsV1alpha1().CStorBackups(bkp.Namespace).Get(bkp.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	nbkp.Status = bkp.Status
+
+	_, err = c.clientset.OpenebsV1alpha1().CStorBackups(nbkp.Namespace).Update(nbkp)
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Completed operation:%v for backup:%v, status:%v", operation, nbkp.Name, nbkp.Status)
+	return nil
+}
+
+// eventHandler will execute a function according to a given operation
+func (c *BackupController) eventHandler(operation common.QueueOperation, bkp *apis.CStorBackup) (string, error) {
+	klog.Infof("%s operation on Backup %s", operation, bkp.Name)
+	switch operation {
+	case common.QOpAdd:
+		return c.addEventHandler(bkp)
+	case common.QOpDestroy:
+		/* TODO: Handle backup destroy event
+		 */
+		return "", nil
+	case common.QOpSync:
+		return c.syncEventHandler(bkp)
+	}
+	return string(apis.BKPCStorStatusInvalid), nil
+}
+
+// addEventHandler will change the state of backup to Init state.
+func (c *BackupController) addEventHandler(bkp *apis.CStorBackup) (string, error) {
+	if !IsPendingStatus(bkp) {
+		return string(apis.BKPCStorStatusInvalid), nil
+	}
+	c.recorder.Event(bkp, corev1.EventTypeNormal, "Update", "initilized backup process")
+	return string(apis.BKPCStorStatusInit), nil
+}
+
+// syncEventHandler will perform the backup if a given backup is in init state
+func (c *BackupController) syncEventHandler(bkp *apis.CStorBackup) (string, error) {
+	// If the backup is in init state then only we will complete the backup
+	if IsInitStatus(bkp) {
+		bkp.Status = apis.BKPCStorStatusInProgress
+		_, err := c.clientset.OpenebsV1alpha1().CStorBackups(bkp.Namespace).Update(bkp)
+		if err != nil {
+			klog.Errorf("Failed to update backup:%s status : %v", bkp.Name, err.Error())
+			return "", err
+		}
+
+		err = volumereplica.CreateVolumeBackup(bkp)
+		if err != nil {
+			c.recorder.Eventf(bkp, corev1.EventTypeWarning, "Backup", "failed to create backup error: %s", err.Error())
+			return string(apis.BKPCStorStatusFailed), err
+		}
+
+		c.recorder.Event(bkp, corev1.EventTypeNormal, "Backup", "backup creation is successful")
+		klog.Infof("backup creation successful: %v, %v", bkp.ObjectMeta.Name, string(bkp.GetUID()))
+		err = c.updateCStorCompletedBackup(bkp)
+		if err != nil {
+			return string(apis.BKPCStorStatusFailed), err
+		}
+		return string(apis.BKPCStorStatusDone), nil
+	}
+	return "", nil
+}
+
+// getCStorBackupResource returns a backup object corresponding to the resource key
+func (c *BackupController) getCStorBackupResource(key string) (*apis.CStorBackup, error) {
+	// Convert the key(namespace/name) string into a distinct name
+	klog.V(1).Infof("Finding backup for key:%s", key)
+	ns, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil, nil
+	}
+
+	bkp, err := c.clientset.OpenebsV1alpha1().CStorBackups(ns).Get(name, metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			runtime.HandleError(fmt.Errorf("bkp '%s' in work queue no longer exists", key))
+			return nil, nil
+		}
+		return nil, err
+	}
+	return bkp, nil
+}
+
+// IsPendingStatus is to check if the backup is in a pending state.
+func IsPendingStatus(bkp *apis.CStorBackup) bool {
+	if string(bkp.Status) == string(apis.BKPCStorStatusPending) {
+		return true
+	}
+	return false
+}
+
+// IsInProgressStatus is to check if the backup is in in-progress state.
+func IsInProgressStatus(bkp *apis.CStorBackup) bool {
+	if string(bkp.Status) == string(apis.BKPCStorStatusInProgress) {
+		return true
+	}
+	return false
+}
+
+// IsInitStatus is to check if the backup is in init state.
+func IsInitStatus(bkp *apis.CStorBackup) bool {
+	if string(bkp.Status) == string(apis.BKPCStorStatusInit) {
+		return true
+	}
+	return false
+}
+
+// IsDoneStatus is to check if the backup is completed or not
+func IsDoneStatus(bkp *apis.CStorBackup) bool {
+	if string(bkp.Status) == string(apis.BKPCStorStatusDone) {
+		return true
+	}
+	return false
+}
+
+// IsFailedStatus is to check if the backup is failed or not
+func IsFailedStatus(bkp *apis.CStorBackup) bool {
+	if string(bkp.Status) == string(apis.BKPCStorStatusFailed) {
+		return true
+	}
+	return false
+}
+
+// IsDestroyEvent is to check if the call is for backup destroy.
+func IsDestroyEvent(bkp *apis.CStorBackup) bool {
+	if bkp.ObjectMeta.DeletionTimestamp != nil {
+		return true
+	}
+	return false
+}
+
+// updateCStorCompletedBackup updates the CStorCompletedBackups resource for the given backup
+// CStorCompletedBackups stores the information of last two completed backups
+// For example, if schedule `b` has last two backups b-0 and b-1 (b-0 created first and after that b-1 was created) having snapshots
+// b-0 and b-1 respectively then CStorCompletedBackups for the schedule `b` will have following information :
+//	CStorCompletedBackups.Spec.PrevSnapName =  b-1
+//  CStorCompletedBackups.Spec.SnapName = b-0
+func (c *BackupController) updateCStorCompletedBackup(bkp *apis.CStorBackup) error {
+	lastbkpname := bkp.Spec.BackupName + "-" + bkp.Spec.VolumeName
+	bkplast, err := c.clientset.OpenebsV1alpha1().CStorCompletedBackups(bkp.Namespace).Get(lastbkpname, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("Failed to get last completed backup for %s vol:%v", bkp.Spec.BackupName, bkp.Spec.VolumeName)
+		return nil
+	}
+
+	// SnapName store the name of 2nd last backed up snapshot
+	bkplast.Spec.SnapName = bkplast.Spec.PrevSnapName
+
+	// PrevSnapName store the name of last backed up snapshot
+	bkplast.Spec.PrevSnapName = bkp.Spec.SnapName
+	_, err = c.clientset.OpenebsV1alpha1().CStorCompletedBackups(bkp.Namespace).Update(bkplast)
+	if err != nil {
+		klog.Errorf("Failed to update lastbackup for %s", bkplast.Name)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/controllers/backup-controller/runner.go
+++ b/pkg/controllers/backup-controller/runner.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backupcontroller
+
+import (
+	"fmt"
+
+	"github.com/openebs/cstor-operators/pkg/controllers/common"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+)
+
+// Run will set up the event handlers for types we are interested in, as well
+// as syncing informer caches and starting workers. It will block until stopCh
+// is closed, at which point it will shutdown the workqueue and wait for
+// workers to finish processing their current work items.
+func (c *BackupController) Run(threadiness int, stopCh <-chan struct{}) error {
+	defer runtime.HandleCrash()
+	defer c.workqueue.ShutDown()
+
+	// Start the informer factories to begin populating the informer caches
+	klog.Info("Starting CStorBackup controller")
+
+	// Wait for the k8s caches to be synced before starting workers
+	klog.Info("Waiting for informer caches to sync")
+	if ok := cache.WaitForCacheSync(stopCh, c.BackupSynced); !ok {
+		return fmt.Errorf("failed to wait for caches to sync")
+	}
+
+	klog.V(1).Info("Starting CStorBackup workers")
+
+	// Launch two workers to process CStorBackup resources
+	for i := 0; i < threadiness; i++ {
+		go wait.Until(c.runWorker, common.ResourceWorkerInterval, stopCh)
+	}
+
+	klog.Info("Started CStorBackup workers")
+	<-stopCh
+	klog.Info("Shutting down CStorBackup workers")
+
+	return nil
+}
+
+// runWorker is a long-running function that will continually call the
+// processNextWorkItem function in order to read and process a message on the
+// workqueue.
+func (c *BackupController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+// processNextWorkItem will read a single work item off the workqueue and
+// attempt to process it, by calling the syncHandler.
+func (c *BackupController) processNextWorkItem() bool {
+	obj, shutdown := c.workqueue.Get()
+
+	if shutdown {
+		return false
+	}
+
+	// We wrap this block in a func so we can defer c.workqueue.Done.
+	err := func(obj interface{}) error {
+		// We call Done here so the workqueue knows we have finished
+		// processing this item. We also must remember to call Forget if we
+		// do not want this work item being re-queued. For example, we do
+		// not call Forget if a transient error occurs, instead the item is
+		// put back on the workqueue and attempted again after a back-off
+		// period.
+		defer c.workqueue.Done(obj)
+		var q common.QueueLoad
+		var ok bool
+		// We expect strings to come off the workqueue. These are of the
+		// form namespace/name. We do this as the delayed nature of the
+		// workqueue means the items in the informer cache may actually be
+		// more up to date that when the item was initially put onto the
+		// workqueue.
+		if q, ok = obj.(common.QueueLoad); !ok {
+			// As the item in the workqueue is actually invalid, we call
+			// Forget here else we'd go into a loop of attempting to
+			// process a work item that is invalid.
+			c.workqueue.Forget(obj)
+			runtime.HandleError(fmt.Errorf("expected string in workqueue but got %#v", obj))
+			return nil
+		}
+		// Run the syncHandler, passing it the namespace/name string of the
+		// CStorBackup resource to be synced.
+		if err := c.syncHandler(q.Key, q.Operation); err != nil {
+			return fmt.Errorf("error syncing '%s': %s", q.Key, err.Error())
+		}
+		// Finally, if no error occurs we Forget this item so it does not
+		// get queued again until another change happens.
+		c.workqueue.Forget(obj)
+		klog.Infof("Successfully synced '%s' for operation: %s", q.Key, string(q.Operation))
+		return nil
+	}(obj)
+
+	if err != nil {
+		runtime.HandleError(err)
+		return true
+	}
+	return true
+}

--- a/vendor/github.com/openebs/api/pkg/apis/openebs.io/v1alpha1/register.go
+++ b/vendor/github.com/openebs/api/pkg/apis/openebs.io/v1alpha1/register.go
@@ -58,6 +58,12 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&BlockDeviceList{},
 		&BlockDeviceClaim{},
 		&BlockDeviceClaimList{},
+		&CStorBackup{},
+		&CStorBackupList{},
+		&CStorCompletedBackup{},
+		&CStorCompletedBackupList{},
+		&CStorRestore{},
+		&CStorRestoreList{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,7 @@ github.com/json-iterator/go
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/openebs/api v1.10.0-RC1.0.20200528063752-522f45d17d59
+# github.com/openebs/api v1.10.0-RC1.0.20200602151240-2b7d2bdbe1ef
 github.com/openebs/api/pkg/apis/cstor
 github.com/openebs/api/pkg/apis/cstor/v1
 github.com/openebs/api/pkg/apis/openebs.io


### PR DESCRIPTION
This PR adds the backup controller to the pool manager.

**Sample output**: kubectl describe -f backup.yaml 
```sh
Name:         snapshot2-pv-687c169c-4ec5-4144-9bcb-a30b75882c56
Namespace:    openebs
Labels:       cstorpoolinstance.openebs.io/name=cspc-stripe-hqqm
              cstorpoolinstance.openebs.io/uid=bdf5571a-899c-4b30-ba23-7aecb9f3c49f
              openebs.io/backup=backup2
              openebs.io/persistent-volume=pv-687c169c-4ec5-4144-9bcb-a30b75882c56
Annotations:  kubectl.kubernetes.io/last-applied-configuration:
                {"apiVersion":"openebs.io/v1alpha1","kind":"CStorBackup","metadata":{"annotations":{},"creationTimestamp":"2020-06-02T15:01:04Z","generati...
API Version:  openebs.io/v1alpha1
Kind:         CStorBackup
Metadata:
  Creation Timestamp:  2020-06-02T15:34:21Z
  Generation:          4
  Resource Version:    7605
  Self Link:           /apis/openebs.io/v1alpha1/namespaces/openebs/cstorbackups/snapshot2-pv-687c169c-4ec5-4144-9bcb-a30b75882c56
  UID:                 f2c6f912-f98b-4b99-8505-20e4d6cee1ba
Spec:
  Backup Dest:     172.102.29.12:3234
  Backup Name:     backup2
  Local Snap:      false
  Prev Snap Name:  
  Snap Name:       snapshot2
  Volume Name:     pv-687c169c-4ec5-4144-9bcb-a30b75882c56
Status:            Failed
Events:
  Type     Reason  Age               From         Message
  ----     ------  ----              ----         -------
  Normal   Synced  88s               CStorBackup  Received Resource create event
  Normal   Update  88s               CStorBackup  initilized backup process
  Normal   Synced  8s (x3 over 88s)  CStorBackup  Received Resource modify event
  Warning  Backup  8s                CStorBackup  failed to create backup error: error: cannot open 'cstor-7a4197af-1b32-4fa5-b2dc-720c302d28f2/pv-687c169c-4ec5-4144-9bcb-a30b75882c56': dataset does not exist
(UNKNOWN) [172.102.29.12] 3234 (?) : Connection timed out
: exit status 1
```

TODO:
1. Add a backup controller testing framework.
2. Push backup related changes into `pkg/backup/`.

**Issues**:
This PR address the issue openebs/openebs#2905, #40

Signed-off-by: mittachaitu sai.chaithanya@mayadata.io