### PR TITLE
refact(cvc-operator): update cvc controller for migration

### DIFF
--- a/pkg/controllers/cstorvolumeconfig/controller.go
+++ b/pkg/controllers/cstorvolumeconfig/controller.go
@@ -208,18 +208,18 @@ func (c *CVCController) syncCVC(cvc *apis.CStorVolumeConfig) error {
 		return nil
 	}
 
-	nodeID := cvc.Publish.NodeID
-	if nodeID == "" {
-		// We choose to absorb the error here as the worker would requeue the
-		// resource otherwise. Instead, the next time the resource is updated
-		// the resource will be queued again.
-		runtime.HandleError(fmt.Errorf("cvc must be publish/attached to Node: %+v", cvc))
-		c.recorder.Event(cvc, corev1.EventTypeWarning,
-			Provisioning,
-			fmt.Sprintf(MessageCVCPublished, cvc.Name),
-		)
-		return nil
-	}
+	// nodeID := cvc.Publish.NodeID
+	// if nodeID == "" {
+	// 	// We choose to absorb the error here as the worker would requeue the
+	// 	// resource otherwise. Instead, the next time the resource is updated
+	// 	// the resource will be queued again.
+	// 	runtime.HandleError(fmt.Errorf("cvc must be publish/attached to Node: %+v", cvc))
+	// 	c.recorder.Event(cvc, corev1.EventTypeWarning,
+	// 		Provisioning,
+	// 		fmt.Sprintf(MessageCVCPublished, cvc.Name),
+	// 	)
+	// 	return nil
+	// }
 
 	if cvc.Status.Phase == apis.CStorVolumeConfigPhasePending {
 		klog.V(2).Infof("provisioning cstor volume %+v", cvc)

--- a/pkg/controllers/cstorvolumeconfig/controller.go
+++ b/pkg/controllers/cstorvolumeconfig/controller.go
@@ -208,19 +208,6 @@ func (c *CVCController) syncCVC(cvc *apis.CStorVolumeConfig) error {
 		return nil
 	}
 
-	// nodeID := cvc.Publish.NodeID
-	// if nodeID == "" {
-	// 	// We choose to absorb the error here as the worker would requeue the
-	// 	// resource otherwise. Instead, the next time the resource is updated
-	// 	// the resource will be queued again.
-	// 	runtime.HandleError(fmt.Errorf("cvc must be publish/attached to Node: %+v", cvc))
-	// 	c.recorder.Event(cvc, corev1.EventTypeWarning,
-	// 		Provisioning,
-	// 		fmt.Sprintf(MessageCVCPublished, cvc.Name),
-	// 	)
-	// 	return nil
-	// }
-
 	if cvc.Status.Phase == apis.CStorVolumeConfigPhasePending {
 		klog.V(2).Infof("provisioning cstor volume %+v", cvc)
 		_, err = c.createVolumeOperation(cvc)

--- a/pkg/controllers/cstorvolumeconfig/volume_operations.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations.go
@@ -324,6 +324,7 @@ func getPolicyBasedPoolList(
 					policyBasedList.Items,
 					pool,
 				)
+				break
 			}
 		}
 	}

--- a/pkg/controllers/cstorvolumeconfig/volume_operations.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations.go
@@ -360,6 +360,12 @@ func (c *CVCController) distributeCVRs(
 	}
 
 	if len(policy.Spec.ReplicaPoolInfo) != 0 {
+		if len(policy.Spec.ReplicaPoolInfo) != claim.Spec.Provision.ReplicaCount {
+			return errors.Errorf("failed to distribute cvrs: incorrect number of pool names in cvc policy: expected %d got %d",
+				claim.Spec.Provision.ReplicaCount,
+				len(policy.Spec.ReplicaPoolInfo),
+			)
+		}
 		poolList = getPolicyBasedPoolList(poolList, policy.Spec.ReplicaPoolInfo)
 	}
 
@@ -379,6 +385,9 @@ func (c *CVCController) distributeCVRs(
 	// prioritized pool instances matched to the given
 	// nodeName in case of replica affinity is enabled via cstor volume policy
 	if c.isReplicaAffinityEnabled(policy) {
+		c.recorder.Eventf(claim, corev1.EventTypeNormal, Provisioning,
+			"replica affinity is enabled, nodeID is "+claim.Publish.NodeID,
+		)
 		usablePoolList = prioritizedPoolList(claim.Publish.NodeID, usablePoolList)
 	}
 


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR 
 - comments out the check for `nodeID` to allow newly created CVC to reconcile for a migrated volume.
 - adds code to honour the replica distribution for pool names mentioned in the CVC spec.