### PR TITLE
fix(cvc): change cvr capacity to provisioned capacity

### DIFF
--- a/pkg/controllers/cstorvolumeconfig/volume_operations.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations.go
@@ -467,6 +467,7 @@ func (c *CVCController) createCVR(
 			cvrObj.Name,
 		)
 	}
+	capacity := claim.Spec.Provision.Capacity[corev1.ResourceStorage]
 	if k8serror.IsNotFound(err) {
 		cvrObj = apis.NewCStorVolumeReplica().
 			WithName(volume.Name + "-" + pool.Name).
@@ -476,7 +477,7 @@ func (c *CVCController) createCVR(
 			WithFinalizers(getCVRFinalizer()).
 			WithTargetIP(service.Spec.ClusterIP).
 			WithReplicaID(rInfo.replicaID).
-			WithCapacity(volume.Spec.Capacity.String()).
+			WithCapacity(capacity.String()).
 			WithNewVersion(version.GetVersion()).
 			WithDependentsUpgraded().
 			WithStatusPhase(rInfo.phase)


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR changes the cvr capacity to the cvc provisioned capacity to avoid any inconsistency when a resized volume is migrated to csi. This will ensure there is no inconsistency in cvrs or snapshots.