### PR TITLE
fix(restore_controller): use the latest env for cspi uid

### DIFF
--- a/pkg/controllers/common/common.go
+++ b/pkg/controllers/common/common.go
@@ -139,9 +139,6 @@ type QueueLoad struct {
 type Environment string
 
 const (
-	// OpenEBSIOCStorID is the environment variable specified in pod.
-	OpenEBSIOCStorID Environment = "OPENEBS_IO_CSTOR_ID"
-	// OpenEBSIOCSPIID is cstorpoolinstance name as environment variable
 	// specified in pool instance pods.
 	OpenEBSIOCSPIID Environment = "OPENEBS_IO_CSPI_ID"
 	// OpenEBSIOPoolName is cstorpoolcluster name as environment variable

--- a/pkg/controllers/replica-controller/handler.go
+++ b/pkg/controllers/replica-controller/handler.go
@@ -484,10 +484,6 @@ func (c *CStorVolumeReplicaController) getVolumeReplicaResource(
 // IsRightCStorVolumeReplica is to check if the cvr
 // request is for particular pod/application.
 func IsRightCStorVolumeReplica(cVR *apis.CStorVolumeReplica) bool {
-	if strings.TrimSpace(string(cVR.ObjectMeta.Labels["cstorpool.openebs.io/uid"])) != "" {
-		return os.Getenv(string(common.OpenEBSIOCStorID)) ==
-			string(cVR.ObjectMeta.Labels["cstorpool.openebs.io/uid"])
-	}
 	if strings.TrimSpace(string(cVR.ObjectMeta.Labels["cstorpoolinstance.openebs.io/uid"])) != "" {
 		return os.Getenv(string(common.OpenEBSIOCSPIID)) ==
 			string(cVR.ObjectMeta.Labels["cstorpoolinstance.openebs.io/uid"])

--- a/pkg/controllers/restore-controller/handler.go
+++ b/pkg/controllers/restore-controller/handler.go
@@ -190,7 +190,7 @@ func IsFailedStatus(rst *apis.CStorRestore) bool {
 
 // IsRightCStorPoolMgmt is to check if the restore request is for particular pod/application.
 func IsRightCStorPoolMgmt(rst *apis.CStorRestore) bool {
-	if os.Getenv(string(common.OpenEBSIOCStorID)) == rst.ObjectMeta.Labels[types.CStorPoolInstanceUIDLabelKey] {
+	if os.Getenv(string(common.OpenEBSIOCSPIID)) == rst.ObjectMeta.Labels[types.CStorPoolInstanceUIDLabelKey] {
 		return true
 	}
 	return false

--- a/pkg/controllers/restore-controller/new_restore_controller.go
+++ b/pkg/controllers/restore-controller/new_restore_controller.go
@@ -200,7 +200,7 @@ func (c *RestoreController) handleRSTUpdateEvent(oldrst, newrst *apis.CStorResto
 
 // cleanupOldRestore set fail status to old pending restore
 func (c *RestoreController) cleanupOldRestore(clientset clientset.Interface) {
-	rstlabel := types.CStorPoolInstanceUIDLabelKey + "=" + os.Getenv(string(common.OpenEBSIOCStorID))
+	rstlabel := types.CStorPoolInstanceUIDLabelKey + "=" + os.Getenv(string(common.OpenEBSIOCSPIID))
 	rstlistop := metav1.ListOptions{
 		LabelSelector: rstlabel,
 	}


### PR DESCRIPTION
This commit changes code to make use of OPENEBS_IO_CSPI_ID env
for getting cspi UID instead of OPENEBS_IO_CSTOR_ID.
OPENEBS_IO_CSTOR_ID is deprecated and not available in
cstor-pool-mgmt container of pool-manager pod where the
restore controller runs.

NOTE: This PR is required in order to support CSI based volume restore 

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>