### PR TITLE
fix(webhook): check for hostname instead of nodename for bd validations

### DIFF
--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -41,7 +41,7 @@ import (
 type PoolValidator struct {
 	poolSpec  *cstor.PoolSpec
 	namespace string
-	nodeName  string
+	hostName  string
 	cspcName  string
 	clientset clientset.Interface
 }
@@ -98,7 +98,7 @@ func (b *Builder) withClientset(c clientset.Interface) *Builder {
 // withPoolNodeName sets the node name field of poolValidator with provided
 // values
 func (b *Builder) withPoolNodeName(nodeName string) *Builder {
-	b.object.nodeName = nodeName
+	b.object.hostName = nodeName
 	return b
 }
 
@@ -389,7 +389,7 @@ func (poolValidator *PoolValidator) raidGroupValidation(
 	return true, ""
 }
 
-func validateBlockDevice(bd *openebsapis.BlockDevice, nodeName string) error {
+func validateBlockDevice(bd *openebsapis.BlockDevice, hostName string) error {
 	if bd.Status.State != "Active" {
 		return errors.Errorf(
 			"block device is in not in active state",
@@ -400,11 +400,11 @@ func validateBlockDevice(bd *openebsapis.BlockDevice, nodeName string) error {
 			bd.Spec.FileSystem.Type,
 		)
 	}
-	if bd.Spec.NodeAttributes.NodeName != nodeName {
+	if bd.Labels[types.HostNameLabelKey] != hostName {
 		return errors.Errorf(
 			"block device %s doesn't belongs to node %s",
 			bd.Name,
-			bd.Spec.NodeAttributes.NodeName,
+			bd.Labels[types.HostNameLabelKey],
 		)
 	}
 	return nil
@@ -427,7 +427,7 @@ func (poolValidator *PoolValidator) blockDeviceValidation(
 			err,
 		)
 	}
-	err = validateBlockDevice(bdObj, poolValidator.nodeName)
+	err = validateBlockDevice(bdObj, poolValidator.hostName)
 
 	if err != nil {
 		return false, fmt.Sprintf("%v", err)


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR fixes the validateBlockdevice check for block devices in the webhook. This case occurs in clusters like EKS where the nodename and hostname label are different.
```sh
mayadata:setup$ kubectl get nodes --show-labels 
NAME                                           STATUS   ROLES    AGE   VERSION   LABELS
ip-192-168-14-68.us-east-2.compute.internal    Ready    <none>   36m   v1.15.9   alpha.eksctl.io/cluster-name=shubham-bajpai-eks,alpha.eksctl.io/instance-id=i-07d31cc59d39279e4,alpha.eksctl.io/nodegroup-name=standard-workers,beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=t3.large,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=us-east-2,failure-domain.beta.kubernetes.io/zone=us-east-2c,kubernetes.io/arch=amd64,kubernetes.io/hostname=ip-192-168-14-68,kubernetes.io/os=linux,topology.cstor.openebs.io/nodeName=ip-192-168-14-68.us-east-2.compute.internal
ip-192-168-36-162.us-east-2.compute.internal   Ready    <none>   36m   v1.15.9   alpha.eksctl.io/cluster-name=shubham-bajpai-eks,alpha.eksctl.io/instance-id=i-024eef20b23cf5336,alpha.eksctl.io/nodegroup-name=standard-workers,beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=t3.large,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=us-east-2,failure-domain.beta.kubernetes.io/zone=us-east-2a,kubernetes.io/arch=amd64,kubernetes.io/hostname=ip-192-168-36-162,kubernetes.io/os=linux,topology.cstor.openebs.io/nodeName=ip-192-168-36-162.us-east-2.compute.internal
ip-192-168-80-245.us-east-2.compute.internal   Ready    <none>   35m   v1.15.9   alpha.eksctl.io/cluster-name=shubham-bajpai-eks,alpha.eksctl.io/instance-id=i-0a0e43bcba501126d,alpha.eksctl.io/nodegroup-name=standard-workers,beta.kubernetes.io/arch=amd64,beta.kubernetes.io/instance-type=t3.large,beta.kubernetes.io/os=linux,failure-domain.beta.kubernetes.io/region=us-east-2,failure-domain.beta.kubernetes.io/zone=us-east-2b,kubernetes.io/arch=amd64,kubernetes.io/hostname=ip-192-168-80-245,kubernetes.io/os=linux,topology.cstor.openebs.io/nodeName=ip-192-168-80-245.us-east-2.compute.internal

```