### PR TITLE
chore(migration): add rbac rules for snapshot migration

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -93,13 +93,13 @@ metadata:
 rules:
 - apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshotclasses"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list"]
 - apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshotcontents"]
-  verbs: ["create", "get", "list", "watch", "update", "delete"]
+  verbs: ["create", "get", "list"]
 - apiGroups: ["snapshot.storage.k8s.io"]
   resources: ["volumesnapshots"]
-  verbs: ["create", "get", "list", "watch", "update"]
+  verbs: ["create", "get", "list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -85,3 +85,32 @@ roleRef:
   name: openebs-cstor-operator
   apiGroup: rbac.authorization.k8s.io
 ---
+# Define Role that allows operations required for migration of snapshots
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-migration
+rules:
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshotcontents"]
+  verbs: ["create", "get", "list", "watch", "update", "delete"]
+- apiGroups: ["snapshot.storage.k8s.io"]
+  resources: ["volumesnapshots"]
+  verbs: ["create", "get", "list", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: openebs-cstor-migration
+subjects:
+- kind: ServiceAccount
+  name: openebs-maya-operator
+  namespace: openebs
+roleRef:
+  kind: ClusterRole
+  name: openebs-cstor-migration
+  apiGroup: rbac.authorization.k8s.io
+---


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>
This PR adds rbac rules for support of snapshot migration.