### PR TITLE
fix(VERSION): omit generation of VERSION file

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -60,20 +60,11 @@ if [ -n "$TRAVIS_TAG" ]; then
     # Example: v1.10.0-custom maps to 1.10.0-custom
     VERSION="${TRAVIS_TAG#v}"
 else
-    ## Counting dots in CURRENT_BRANCH. If it is
-    ## release branch then it will have more than
-    ## one dot(.) because we are following release
-    ## branch naming convention as v1.10.x, v0.9.x
-    ## v2.0.x, v1.0.x
-
-    ## If we compare with master then local building
-    ## will have unknown version
-    dot_count=$(echo "${CURRENT_BRANCH}" | grep -o "\." | wc -l)
-    if [ "${dot_count}" -gt 1 ]; then
-        VERSION="${CURRENT_BRANCH#v}-dev"
-    else
-        VERSION="dev"
-    fi
+    ## Marking VERSION as current_branch-dev
+    ## Example: master branch maps to master-dev
+    ## Example: v1.11.x-ee branch to 1.11.x-ee-dev
+    ## Example: v1.10.x branch to 1.10.x-dev
+    VERSION="${CURRENT_BRANCH#v}-dev"
 fi
 
 echo "Building for ${VERSION} VERSION"

--- a/build/build.sh
+++ b/build/build.sh
@@ -17,16 +17,6 @@
 # This script builds the application from source for multiple platforms.
 set -e
 
-VERSION_FILE_PATH="$GOPATH/src/github.com/openebs/cstor-operators/VERSION"
-
-on_exit() {
-    ## Delete VERSION file
-    echo "Deleteing VERSION File($VERSION_FILE_PATH) that got generated during build time"
-    rm -f "$VERSION_FILE_PATH"
-}
-
-trap 'on_exit' EXIT
-
 # Get the parent directory of where this script is.
 SOURCE="${BASH_SOURCE[0]}"
 while [ -h "$SOURCE" ] ; do SOURCE="$(readlink "$SOURCE")"; done
@@ -51,6 +41,15 @@ fi
 # Get the version details
 #VERSION="$(cat $GOPATH/src/github.com/openebs/cstor-operators/VERSION)"
 
+# Determine the current branch
+CURRENT_BRANCH=""
+if [ -z "${TRAVIS_BRANCH}" ];
+then
+  CURRENT_BRANCH=$(git branch | grep "\*" | cut -d ' ' -f2)
+else
+  CURRENT_BRANCH="${TRAVIS_BRANCH}"
+fi
+
 ## Populate the version based on release tag
 ## If travis tag is set then assign it as VERSION and
 ## if travis tag is empty then mark version as ci
@@ -61,12 +60,23 @@ if [ -n "$TRAVIS_TAG" ]; then
     # Example: v1.10.0-custom maps to 1.10.0-custom
     VERSION="${TRAVIS_TAG#v}"
 else
-    VERSION="dev"
+    ## Counting dots in CURRENT_BRANCH. If it is
+    ## release branch then it will have more than
+    ## one dot(.) because we are following release
+    ## branch naming convention as v1.10.x, v0.9.x
+    ## v2.0.x, v1.0.x
+
+    ## If we compare with master then local building
+    ## will have unknown version
+    dot_count=$(echo "${CURRENT_BRANCH}" | grep -o "\." | wc -l)
+    if [ "${dot_count}" -gt 1 ]; then
+        VERSION="${CURRENT_BRANCH#v}-dev"
+    else
+        VERSION="dev"
+    fi
 fi
 
-echo "Building for VERSION ${VERSION}"
-## Below line will help to get current version for various binaries
-echo "${VERSION}" > "$VERSION_FILE_PATH"
+echo "Building for ${VERSION} VERSION"
 
 #VERSION=$(git describe --tags --always --dirty)
 


### PR DESCRIPTION
This PR does the following changes:
- Omits the VERSION file generation.
- Populates the current and desired version details for CVC if it is empty.

VERSION can have the following possible values:
- If Travis_TAG is set then `TRAVIS_TAG` then corresponding
   tag will be the value.
- If TRAVIS_TAG is not set then the value will be  `${branch_name}-dev`

**Why we need this PR**:
This PR will populate the value of `openebs.io/version` and internal
resource version details based on build tag and build branch.


**Special Note To Reviewers**:
- VERSION value will be set on internal resources created by CVC and CSPC operators.
- This PR is continuation of #104 

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>