### PR TITLE
feat(cvc): user policy based target podAffinity for target deployment

### DIFF
--- a/pkg/controllers/cstorvolumeconfig/deployment.go
+++ b/pkg/controllers/cstorvolumeconfig/deployment.go
@@ -149,6 +149,16 @@ func getDeployTemplateAffinity() *corev1.Affinity {
 	}
 }
 
+// getTargetTemplateAffinity returns affinities for target deployement
+func getTargetTemplateAffinity(policySpec *apis.CStorVolumePolicySpec) *corev1.Affinity {
+	if policySpec.Target.PodAffinity == nil {
+		return &corev1.Affinity{}
+	}
+	return &corev1.Affinity{
+		PodAffinity: policySpec.Target.PodAffinity,
+	}
+}
+
 // getDeployTolerations returns the array of toleration
 // for target deployement, defaulTolerations will be return if not provided
 func getDeployTolerations(policySpec *apis.CStorVolumePolicySpec) []corev1.Toleration {
@@ -377,8 +387,7 @@ func (c *CVCController) BuildTargetDeployment(
 				WithLabelsNew(getDeployTemplateLabels(vol.Name)).
 				WithAnnotationsNew(getDeployTemplateAnnotations()).
 				WithServiceAccountName(util.GetServiceAccountName()).
-				// TODO use of affinity
-				//WithAffinity(getDeployTemplateAffinity()).
+				WithAffinity(getTargetTemplateAffinity(policySpec)).
 				WithPriorityClassName(getPriorityClass(policySpec)).
 				WithNodeSelectorByValue(policySpec.Target.NodeSelector).
 				WithTolerationsNew(getDeployTolerations(policySpec)...).


### PR DESCRIPTION
commit enhances the cstorvolumepolicy to use any key:value pair
as a target podAffinity set in target deployment while provisioning and
scheduling

Below is the example to use policy to configure the affinity and other
policies

```
apiVersion: cstor.openebs.io/v1
kind: CStorVolumePolicy
metadata:
  name: csi-volume-policy
  namespace: openebs
spec:
  provision:
    replicaAffinity: true
  replica:
    zvolWorkers: ""
  target:
    resources:
      requests:
        memory: "64Mi"
        cpu: "250m"
      limits:
        memory: "128Mi"
        cpu: "500m"
    auxResources:
      requests:
        memory: "64Mi"
        cpu: "250m"
      limits:
        memory: "128Mi"
        cpu: "500m"
    tolerations:
      - key: "key1"
        operator: "Equal"
        value: "value1"
        effect: "NoSchedule"
    priorityClassName: "system-cluster-critical"
    affinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: openebs.io/target-affinity
            operator: In
            values:
            - percona
        topologyKey: kubernetes.io/hostname
        namespaces: ["default"]

```

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>