### PR TITLE
refact(cvp): initialize cvr zvolworkers based on policy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0 // indirect
 	github.com/onsi/gomega v1.9.0 // indirect
-	github.com/openebs/api v1.11.1-0.20200625121525-4ef7efa4b876
+	github.com/openebs/api v1.11.1-0.20200629052954-e52e2bcd8339
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -387,10 +387,8 @@ github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zM
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openebs/api v1.10.0-RC1.0.20200608150240-08b494f77b77 h1:Daq7JniS96LQOSOgneBwEIYOZDh4iuxZBOy6jbw5LHo=
-github.com/openebs/api v1.10.0-RC1.0.20200608150240-08b494f77b77/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
-github.com/openebs/api v1.11.1-0.20200625121525-4ef7efa4b876 h1:c6HE7cROx9mC+yJ8h9SO8J1PPAxEatbpw+vH9TpSWj0=
-github.com/openebs/api v1.11.1-0.20200625121525-4ef7efa4b876/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
+github.com/openebs/api v1.11.1-0.20200629052954-e52e2bcd8339 h1:T6IuGc8zikB4XG+s8QTyTruJ35s1fm/P41z1AGj2rkI=
+github.com/openebs/api v1.11.1-0.20200629052954-e52e2bcd8339/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/controllers/cstorvolumeconfig/volume_operations.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations.go
@@ -61,6 +61,7 @@ const (
 type replicaInfo struct {
 	replicaID string
 	phase     apis.CStorVolumeReplicaPhase
+	ioWorkers string
 }
 
 var (
@@ -347,7 +348,8 @@ func (c *CVCController) distributeCVRs(
 		err            error
 	)
 	rInfo := replicaInfo{
-		phase: apis.CVRStatusEmpty,
+		phase:     apis.CVRStatusEmpty,
+		ioWorkers: policy.Spec.Replica.IOWorkers,
 	}
 
 	cspcName := getCSPC(claim)
@@ -478,6 +480,7 @@ func (c *CVCController) createCVR(
 			WithTargetIP(service.Spec.ClusterIP).
 			WithReplicaID(rInfo.replicaID).
 			WithCapacity(capacity.String()).
+			WithZvolWorkers(rInfo.ioWorkers).
 			WithNewVersion(version.GetVersion()).
 			WithDependentsUpgraded().
 			WithStatusPhase(rInfo.phase)
@@ -839,6 +842,7 @@ func (c *CVCController) handleVolumeReplicaCreation(cvc *apis.CStorVolumeConfig,
 		rInfo := replicaInfo{
 			replicaID: hash,
 			phase:     apis.CVRStatusRecreate,
+			ioWorkers: cvc.Spec.Policy.Replica.IOWorkers,
 		}
 		_, err = c.createCVR(svcObj, cvObj, cvc, cspiObj, rInfo)
 		if err != nil {

--- a/vendor/github.com/openebs/api/pkg/apis/cstor/v1/cstorvolumebuilder.go
+++ b/vendor/github.com/openebs/api/pkg/apis/cstor/v1/cstorvolumebuilder.go
@@ -606,6 +606,18 @@ func (cvr *CStorVolumeReplica) WithReplicaID(replicaID string) *CStorVolumeRepli
 	return cvr
 }
 
+// WithZvolWorkers sets the zvolworkers with the provided arguments
+func (cvr *CStorVolumeReplica) WithZvolWorkers(zvolworker string) *CStorVolumeReplica {
+	cvr.Spec.ZvolWorkers = zvolworker
+	return cvr
+}
+
+// WithCWithCompression sets the compression algorithm with the provided arguments
+func (cvr *CStorVolumeReplica) WithCompression(compression string) *CStorVolumeReplica {
+	cvr.Spec.Compression = compression
+	return cvr
+}
+
 // WithStatusPhase sets the Status Phase of CStorVolumeReplica with provided
 //arguments
 func (cvr *CStorVolumeReplica) WithStatusPhase(phase CStorVolumeReplicaPhase) *CStorVolumeReplica {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -46,7 +46,7 @@ github.com/json-iterator/go
 github.com/modern-go/concurrent
 # github.com/modern-go/reflect2 v1.0.1
 github.com/modern-go/reflect2
-# github.com/openebs/api v1.11.1-0.20200625121525-4ef7efa4b876
+# github.com/openebs/api v1.11.1-0.20200629052954-e52e2bcd8339
 github.com/openebs/api/pkg/apis/cstor
 github.com/openebs/api/pkg/apis/cstor/v1
 github.com/openebs/api/pkg/apis/openebs.io


### PR DESCRIPTION
**What this change does **

PR initialize the CVR zvolworkers tunnables based on the given policy created  by the user
below is the example policy to configure different cstor tunnables 

```yaml
apiVersion: cstor.openebs.io/v1
kind: CStorVolumePolicy
metadata:
  name: csi-volume-policy
  namespace: openebs
spec:
  provision:
    replicaAffinity: true
  replica:
    zvolWorkers: "6"
  target:
    luWorkers: 8
    queueDepth: "16"
    resources:
      requests:
        memory: "64Mi"
        cpu: "250m"
      limits:
        memory: "128Mi"
        cpu: "500m"
    auxResources:
      requests:
        memory: "64Mi"
        cpu: "250m"
      limits:
        memory: "128Mi"
        cpu: "500m"
    .
    .
    .
```


Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>