### PR TITLE
fix(version): split version string to segregate version from tags

### DIFF
--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -8,7 +8,7 @@ var (
 	validCurrentVersions = map[string]bool{
 		"1.9.0": true, "1.10.0": true,
 	}
-	validDesiredVersion = GetVersion()
+	validDesiredVersion = strings.Split(GetVersion(), "-")[0]
 )
 
 // IsCurrentVersionValid verifies if the  current version is valid or not

--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	validCurrentVersions = map[string]bool{
-		"1.9.0": true, "1.10.0": true,
+		"1.9.0": true, "1.10.0": true, "1.11.0": true,
 	}
 	validDesiredVersion = strings.Split(GetVersion(), "-")[0]
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR fixes the version check for valid desired version which needs to be split from the tags in the version string. Example: 1.11.0-RC1 needs to split and 1.11.0 is the actual version.