### PR TITLE
fix(cstor-webhook): fixes pool scaledown bug

### DIFF
--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -529,14 +529,13 @@ func (p *PoolOperations) ValidateScaledown() (bool, string) {
 			}
 		}
 
-		ls := &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				types.CStorPoolClusterLabelKey: p.OldCSPC.Name,
-				types.HostNameLabelKey:         oldPool.NodeSelector[types.HostNameLabelKey],
-			},
-		}
-
 		if !found && p.IsScaledownCase(oldPool) {
+			ls := &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					types.CStorPoolClusterLabelKey: p.OldCSPC.Name,
+					types.HostNameLabelKey:         oldPool.NodeSelector[types.HostNameLabelKey],
+				},
+			}
 			cspi, err := p.clientset.CstorV1().CStorPoolInstances(p.OldCSPC.Namespace).
 				List(metav1.ListOptions{
 					LabelSelector: labels.Set(ls.MatchLabels).String(),


### PR DESCRIPTION
In case of scaling down a pool by removing a pool spec from the CSPC, the webhook server was reporting an out of bounds error. This commit fixes this bug.

**Bug Description:**  
The validation code, in case of scaledown, was trying to list CSPI based on all the labels present on the nodes of the corresponding CSPI. On the other hand, CSPI only has `kubernetes.io/hostname` label to it and not all the other node labels. As labels are ANDed for output, we were not getting any items in the CSPI list and hence out of bounds error was caused.




Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>