### PR TITLE
refact(cvc): add pvc label in volume target deployments

### DIFF
--- a/pkg/controllers/cstorvolumeconfig/deployment.go
+++ b/pkg/controllers/cstorvolumeconfig/deployment.go
@@ -76,13 +76,14 @@ var (
 	MgmtContainerName = "cstor-volume-mgmt"
 )
 
-func getDeployLabels(pvName string) map[string]string {
+func getDeployLabels(pvName, pvcName string) map[string]string {
 	return map[string]string{
 		"app":                            "cstor-volume-manager",
 		"openebs.io/target":              "cstor-target",
 		"openebs.io/storage-engine-type": "cstor",
 		"openebs.io/cas-type":            "cstor",
 		"openebs.io/persistent-volume":   pvName,
+		openebsPVC:                       pvcName,
 		"openebs.io/version":             version.GetVersion(),
 	}
 }
@@ -102,12 +103,13 @@ func getDeployMatchLabels(pvName string) map[string]string {
 	}
 }
 
-func getDeployTemplateLabels(pvName string) map[string]string {
+func getDeployTemplateLabels(pvName, pvcName string) map[string]string {
 	return map[string]string{
 		"monitoring":                   "volume_exporter_prometheus",
 		"app":                          "cstor-volume-manager",
 		"openebs.io/target":            "cstor-target",
 		"openebs.io/persistent-volume": pvName,
+		openebsPVC:                     pvcName,
 		"openebs.io/version":           version.GetVersion(),
 	}
 }
@@ -374,7 +376,7 @@ func (c *CVCController) BuildTargetDeployment(
 
 	deployObj := deploy.NewDeployment().
 		WithName(vol.Name + "-target").
-		WithLabelsNew(getDeployLabels(vol.Name)).
+		WithLabelsNew(getDeployLabels(vol.Name, vol.GetLabels()[openebsPVC])).
 		WithAnnotationsNew(getDeployAnnotation()).
 		WithOwnerReferenceNew(getDeployOwnerReference(vol)).
 		WithReplicas(&deployreplicas).
@@ -384,7 +386,7 @@ func (c *CVCController) BuildTargetDeployment(
 		WithSelectorMatchLabelsNew(getDeployMatchLabels(vol.Name)).
 		WithPodTemplateSpec(
 			apicore.NewPodTemplateSpec().
-				WithLabelsNew(getDeployTemplateLabels(vol.Name)).
+				WithLabelsNew(getDeployTemplateLabels(vol.Name, vol.GetLabels()[openebsPVC])).
 				WithAnnotationsNew(getDeployTemplateAnnotations()).
 				WithServiceAccountName(util.GetServiceAccountName()).
 				WithAffinity(getTargetTemplateAffinity(policySpec)).

--- a/pkg/controllers/cstorvolumeconfig/volume_operations.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations.go
@@ -48,6 +48,8 @@ const (
 	// pvSelector is the selector key for cstorvolumereplica belongs to a cstor
 	// volume
 	pvSelector = "openebs.io/persistent-volume"
+	// openebsPVC represents the persistentvoolumeclaim name
+	openebsPVC = "openebs.io/persistent-volume-claim"
 	// minHAReplicaCount is minimum no.of replicas are required to decide
 	// HighAvailable volume
 	minHAReplicaCount = 3
@@ -168,6 +170,7 @@ func getCVLabels(claim *apis.CStorVolumeConfig) map[string]string {
 	return map[string]string{
 		"openebs.io/persistent-volume": claim.Name,
 		"openebs.io/version":           version.GetVersion(),
+		openebsPVC:                     claim.GetAnnotations()[openebsPVC],
 	}
 }
 


### PR DESCRIPTION
commit add the persistentvolumeclaim label
"openebs.io/persistent-volume-claim" in volume target
deployments while volume provisioning

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>
(cherry picked from commit 82435a2bd6d46fe1a145ba4d7bc2324d4d939100)