### PR TITLE
fix(status): update CSPI status when corresponding cStor pool-manager terminated

### DIFF
--- a/build/pool-manager/Dockerfile
+++ b/build/pool-manager/Dockerfile
@@ -30,5 +30,5 @@ LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
-ENTRYPOINT entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 EXPOSE 7676

--- a/build/pool-manager/entrypoint.sh
+++ b/build/pool-manager/entrypoint.sh
@@ -22,7 +22,7 @@ waitForChildProcessToFinish(){
 }
 
 rm /usr/local/bin/zrepl
-exec /usr/local/bin/pool-manager start &
+/usr/local/bin/pool-manager start &
 pool_manager_pid=$!
 
 #exec service ssh start

--- a/build/pool-manager/entrypoint.sh
+++ b/build/pool-manager/entrypoint.sh
@@ -1,8 +1,34 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ex
 
+#sigterm caught SIGTERM signal and forward it to pool_manager process
+_sigterm() {
+  echo "[entrypoint.sh] caught SIGTERM signal forwarding to pid [$pool_manager_pid]."
+  kill -TERM "$pool_manager_pid" 2> /dev/null
+  waitForChildProcessToFinish
+}
+
+#sigint caught SIGINT signal and forward it to pool_manager process
+_sigint() {
+  echo "[entrypoint.sh] caught SIGINT signal forwarding to pid [$pool_manager_pid]."
+  kill -INT "$pool_manager_pid" 2> /dev/null
+  waitForChildProcessToFinish
+}
+
+#waitForChildProcessToFinish waits for pool_manager process to finish
+waitForChildProcessToFinish(){
+    while ps -p "$pool_manager_pid" > /dev/null; do sleep 1; done;
+}
+
 rm /usr/local/bin/zrepl
-exec /usr/local/bin/pool-manager start
-exec service ssh start
-exec service rsyslog start
+exec /usr/local/bin/pool-manager start &
+pool_manager_pid=$!
+
+#exec service ssh start
+#exec service rsyslog start
+
+trap '_sigint' INT
+trap '_sigterm' SIGTERM
+
+wait $pool_manager_pid

--- a/pkg/controllers/cspi-controller/handler.go
+++ b/pkg/controllers/cspi-controller/handler.go
@@ -544,6 +544,7 @@ func (c *CStorPoolInstanceController) markCSPIStatusToOffline() {
 			_, err = c.clientset.CstorV1().CStorPoolInstances(cspi.Namespace).Update(&cspi)
 			if err != nil {
 				klog.Errorf("Failed to update CSPI: %s status to %s", cspi.Name, cstor.CStorPoolStatusOffline)
+				return
 			}
 			klog.Infof("Status marked %s for CSPI: %s", cstor.CStorPoolStatusOffline, cspi.Name)
 			break

--- a/pkg/controllers/cspi-controller/handler.go
+++ b/pkg/controllers/cspi-controller/handler.go
@@ -194,7 +194,7 @@ func (c *CStorPoolInstanceController) reconcile(key string) error {
 		// zpool commands will error out and fall into this scenario
 		c.recorder.Event(cspi, corev1.EventTypeWarning,
 			string(common.FailedSynced),
-			fmt.Sprintf("Unable to import a pool may be due to underlying pool disk might be lost or bad disk might be attached to the node"),
+			fmt.Sprintf("Failed to import the pool as the underlying pool might be lost or the disk(s) has gone bad"),
 		)
 		// Set Pool Lost condition to true
 		condition := cspiutil.NewCSPICondition(

--- a/pkg/controllers/cspi-controller/handler_test.go
+++ b/pkg/controllers/cspi-controller/handler_test.go
@@ -2135,6 +2135,9 @@ func TestRun(t *testing.T) {
 							Namespace: "openebs",
 							UID:       k8stypes.UID("1234"),
 						},
+						Status: cstor.CStorPoolInstanceStatus{
+							Phase: "OFFLINE",
+						},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{
@@ -2178,6 +2181,79 @@ func TestRun(t *testing.T) {
 							Name:      "test-2-cspi-3",
 							Namespace: "openebs",
 							UID:       k8stypes.UID("ADSA123456"),
+						},
+					},
+				},
+			},
+			updatedCSPIName:     "",
+			stopChan:            make(chan struct{}),
+			expectedActionCount: 1,
+		},
+		"When pool is not created but pool-manager restarted": {
+			cspiList: &cstor.CStorPoolInstanceList{
+				Items: []cstor.CStorPoolInstance{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-3-cspi-1",
+							Namespace: "openebs",
+							UID:       k8stypes.UID("1234"),
+						},
+						Status: cstor.CStorPoolInstanceStatus{
+							Phase: "",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-3-cspi-2",
+							Namespace: "openebs",
+							UID:       k8stypes.UID("1234ABC"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-3-cspi-3",
+							Namespace: "openebs",
+							UID:       k8stypes.UID("123456"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-3-cspi-4",
+							Namespace: "openebs",
+							UID:       k8stypes.UID("ADSA123456"),
+						},
+					},
+				},
+			},
+			updatedCSPIName:     "",
+			stopChan:            make(chan struct{}),
+			expectedActionCount: 1,
+		},
+		"When users are trying to recreate a pool manually": {
+			cspiList: &cstor.CStorPoolInstanceList{
+				Items: []cstor.CStorPoolInstance{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-4-cspi-1",
+							Namespace: "openebs",
+							UID:       k8stypes.UID("1234"),
+						},
+						Status: cstor.CStorPoolInstanceStatus{
+							Phase: cstor.CStorPoolStatusPending,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-4-cspi-2",
+							Namespace: "openebs",
+							UID:       k8stypes.UID("1234ABC"),
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-4-cspi-3",
+							Namespace: "openebs",
+							UID:       k8stypes.UID("123456"),
 						},
 					},
 				},

--- a/pkg/controllers/cspi-controller/runner.go
+++ b/pkg/controllers/cspi-controller/runner.go
@@ -50,6 +50,18 @@ func (c *CStorPoolInstanceController) Run(threadiness int, stopCh <-chan struct{
 
 	klog.Info("Started CStorPoolInstance workers")
 	<-stopCh
+
+	klog.Info("changing the CSPI state to offline before shutting down")
+	// TODO: Should we mark CSPI.Status.Phase to Unknown(decide before merging PR)?
+
+	// Changing the state of corresponding CSPI to Offline before shutting down.
+	// Similar as when pod is running and if you stopped kubelet it will make
+	// pod status unknown.
+	// NOTE: CSPI status will be updated to OFFLINE even cStor pool-manager
+	// container alone get restarted but in this case pool will be still in
+	// running state. This inconsistency will be resolved in subsequent reconciliations
+	c.markCSPIStatusToOffline()
+
 	klog.Info("Shutting down CStorPoolInstance workers")
 
 	return nil


### PR DESCRIPTION
This PR updates the CSPI status to **OFFLINE** whenever
cStor pool-manager container is terminated. Pod deletion, eviction,
scale down are a few scenarios that will cause the container
to terminate.

**NOTE**: Status will be not updated in case of aburupt
the shutdown of pods/nodes.

This PR fixes: #128 

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>