### PR TITLE
chore(docs): add prerequisite to install CStor-CSI on rancher based cluster

### DIFF
--- a/docs/quick.md
+++ b/docs/quick.md
@@ -8,11 +8,13 @@ meets the following prerequisites:
 1. You will need to have Kubernetes version 1.14 or higher.
 2. iSCSI initiator utils installed on all the worker nodes(If you are using rancher based cluster perform steps mentioned [here](troubleshooting/rancher_prerequisite.md)).
 
+
 | OPERATING SYSTEM | ISCSI PACKAGE         | Commands to install iSCSI                                | Verify iSCSI Status         |
 | ---------------- | --------------------- | -------------------------------------------------------- | --------------------------- |
 | RHEL/CentOS      | iscsi-initiator-utils | <ul><li>sudo yum install iscsi-initiator-utils -y</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ul> | sudo systemctl status iscsid.service |
 | Ununtu/ Debian   | open-iscsi            |  <ul><li>sudo apt install open-iscsi</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ui>| sudo systemctl status iscsid.service |
-| RancherOS        | open-iscsi            |  <ul><li>sudo ros s enable open-iscsi</li><li>sudo ros s up open-iscsi</li></ui>| - |
+| RancherOS        | open-iscsi            |  <ul><li>sudo ros s enable open-iscsi</li><li>sudo ros s up open-iscsi</li></ui>| ros service list iscsi |
+
 
 3. You have access to install RBAC components into kube-system namespace.
 4. You have disks attached to nodes to provision storage.

--- a/docs/quick.md
+++ b/docs/quick.md
@@ -5,8 +5,8 @@
 Before setting up cStor operators make sure your Kubernetes Cluster
 meets the following prerequisites:
 
-1. You will need to have Kubernetes version 1.14 or higher
-2. iSCSI initiator utils installed on all the worker nodes
+1. You will need to have Kubernetes version 1.14 or higher.
+2. iSCSI initiator utils installed on all the worker nodes(If you are using rancher based cluster perform [these](troubleshooting/rancher_prerequisite.md) steps).
 3. You have access to install RBAC components into kube-system namespace.
 4. You have disks attached to nodes to provision storage.
 

--- a/docs/quick.md
+++ b/docs/quick.md
@@ -9,7 +9,7 @@ meets the following prerequisites:
 2. iSCSI initiator utils installed on all the worker nodes(If you are using rancher based cluster perform steps mentioned [here](troubleshooting/rancher_prerequisite.md)).
 
 
-| OPERATING SYSTEM | ISCSI PACKAGE         | Commands to install iSCSI                                | Verify iSCSI Status         |
+| OPERATING SYSTEM | iSCSI PACKAGE         | Commands to install iSCSI                                | Verify iSCSI Status         |
 | ---------------- | --------------------- | -------------------------------------------------------- | --------------------------- |
 | RHEL/CentOS      | iscsi-initiator-utils | <ul><li>sudo yum install iscsi-initiator-utils -y</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ul> | sudo systemctl status iscsid.service |
 | Ununtu/ Debian   | open-iscsi            |  <ul><li>sudo apt install open-iscsi</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ui>| sudo systemctl status iscsid.service |

--- a/docs/quick.md
+++ b/docs/quick.md
@@ -6,9 +6,24 @@ Before setting up cStor operators make sure your Kubernetes Cluster
 meets the following prerequisites:
 
 1. You will need to have Kubernetes version 1.14 or higher.
-2. iSCSI initiator utils installed on all the worker nodes(If you are using rancher based cluster perform [these](troubleshooting/rancher_prerequisite.md) steps).
+2. iSCSI initiator utils installed on all the worker nodes(If you are using rancher based cluster perform steps mentioned [here](troubleshooting/rancher_prerequisite.md)).
 3. You have access to install RBAC components into kube-system namespace.
 4. You have disks attached to nodes to provision storage.
+
+#### Install iSCSI initiator and load iSCSI modules
+
+| OPERATING SYSTEM | ISCSI PACKAGE         | COMMANDS                                                 |
+| ---------------- | --------------------- | -------------------------------------------------------- |
+| RHEL/CentOS      | iscsi-initiator-utils | <ul><li>sudo yum install iscsi-initiator-utils -y</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ul> |
+| Ununtu/ Debian   | open-iscsi            |  <ul><li>sudo apt install open-iscsi</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ui>|
+| RancherOS        | open-iscsi            |  <ul><li>sudo ros s enable open-iscsi</li><li>sudo ros s up open-iscsi</li></ui>|
+
+- Verification of iscsi service:
+
+```sh
+  sudo systemctl status iscsid.service
+```
+**NOTE**: Above command will vary depends on the OS.
 
 ### Insallation
 

--- a/docs/quick.md
+++ b/docs/quick.md
@@ -7,23 +7,15 @@ meets the following prerequisites:
 
 1. You will need to have Kubernetes version 1.14 or higher.
 2. iSCSI initiator utils installed on all the worker nodes(If you are using rancher based cluster perform steps mentioned [here](troubleshooting/rancher_prerequisite.md)).
+
+| OPERATING SYSTEM | ISCSI PACKAGE         | Commands to install iSCSI                                | Verify iSCSI Status         |
+| ---------------- | --------------------- | -------------------------------------------------------- | --------------------------- |
+| RHEL/CentOS      | iscsi-initiator-utils | <ul><li>sudo yum install iscsi-initiator-utils -y</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ul> | sudo systemctl status iscsid.service |
+| Ununtu/ Debian   | open-iscsi            |  <ul><li>sudo apt install open-iscsi</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ui>| sudo systemctl status iscsid.service |
+| RancherOS        | open-iscsi            |  <ul><li>sudo ros s enable open-iscsi</li><li>sudo ros s up open-iscsi</li></ui>| - |
+
 3. You have access to install RBAC components into kube-system namespace.
 4. You have disks attached to nodes to provision storage.
-
-#### Install iSCSI initiator and load iSCSI modules
-
-| OPERATING SYSTEM | ISCSI PACKAGE         | COMMANDS                                                 |
-| ---------------- | --------------------- | -------------------------------------------------------- |
-| RHEL/CentOS      | iscsi-initiator-utils | <ul><li>sudo yum install iscsi-initiator-utils -y</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ul> |
-| Ununtu/ Debian   | open-iscsi            |  <ul><li>sudo apt install open-iscsi</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ui>|
-| RancherOS        | open-iscsi            |  <ul><li>sudo ros s enable open-iscsi</li><li>sudo ros s up open-iscsi</li></ui>|
-
-- Verification of iscsi service:
-
-```sh
-  sudo systemctl status iscsid.service
-```
-**NOTE**: Above command will vary depends on the OS.
 
 ### Insallation
 

--- a/docs/troubleshooting/migrate_cstor_volume.md
+++ b/docs/troubleshooting/migrate_cstor_volume.md
@@ -228,7 +228,7 @@ pvc-81746e7a-a29d-423b-a048-76edab0b0826-cstor-cspc-zdvk   6K     6K          He
 ```sh
 $ kubectl get cspi -n openebs
 NAME              HOSTNAME            ALLOCATED  FREE   CAPACITY  READONLY  PROVISIONEDREPLICAS  HEALTHYREPLICAS  TYPE    STATUS  AGE
-cstor-cspc-bf9h  ip-192-168-49-174  230k       9630M  9630230k  false     1                    1                stripe  ONLINE  66s
+cstor-cspc-bf9h  ip-192-168-49-174    230k       9630M  9630230k  false     1                    1                stripe  ONLINE  66s
 cstor-cspc-xnxx   ip-192-168-79-76    101k       9630M  9630101k  false     1                    1                stripe  ONLINE  4m25s
 cstor-cspc-zdvk   ip-192-168-29-217   98k        9630M  9630098k  false     1                    1                stripe  ONLINE  4m25s
 ```

--- a/docs/troubleshooting/rancher_prerequisite.md
+++ b/docs/troubleshooting/rancher_prerequisite.md
@@ -31,7 +31,7 @@ Below commands are required to verify and install iscsi services on nodes
 
 | OPERATING SYSTEM | ISCSI PACKAGE         | COMMANDS                                                 |
 | ---------------- | --------------------- | -------------------------------------------------------- |
-| RHEL/CentOS      | iscsi-initiator-utils | <ul><li>yum install iscsi-initiator-utils -y</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ul> |
+| RHEL/CentOS      | iscsi-initiator-utils | <ul><li>sudo yum install iscsi-initiator-utils -y</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ul> |
 | Ununtu/ Debian   | open-iscsi            |  <ul><li>sudo apt install open-iscsi</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ui>|
 
 #### Step2: Add extra_binds under kubelet service in cluster YAML

--- a/docs/troubleshooting/rancher_prerequisite.md
+++ b/docs/troubleshooting/rancher_prerequisite.md
@@ -29,17 +29,10 @@ reboot
 
 Below commands are required to verify and install iscsi services on nodes
 
-| OPERATING SYSTEM | ISCSI PACKAGE         | COMMANDS                                               |
-|---------------------------------------------------------------------------------------------------|
-|                  | iscsi-initiator-utils | yum install iscsi-initiator-utils -y	                |
-| RHEL/CentOS      |                       | sudo systemctl enable --now iscsid                     |
-|                  |                       | modprobe iscsi_tcp                                     |
-|                  |                       | echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf     |
-|---------------------------------------------------------------------------------------------------|
-|                  |                       | sudo apt install open-iscsi                            |
-| Ununtu/ Debian   |                       | sudo systemctl enable --now iscsid                     |
-|                  |                       | modprobe iscsi_tcp                                     |
-|                  |                       | echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf     |
+| OPERATING SYSTEM | ISCSI PACKAGE         | COMMANDS                                                 |
+| ---------------- | --------------------- | -------------------------------------------------------- |
+| RHEL/CentOS      | iscsi-initiator-utils | <ul><li>yum install iscsi-initiator-utils -y</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ul> |
+| Ununtu/ Debian   | open-iscsi            |  <ul><li>sudo apt install open-iscsi</li><li>sudo systemctl enable --now iscsid</li><li>modprobe iscsi_tcp</li><li>echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf</li></ui>|
 
 #### Step2: Add extra_binds under kubelet service in cluster YAML
 

--- a/docs/troubleshooting/rancher_prerequisite.md
+++ b/docs/troubleshooting/rancher_prerequisite.md
@@ -1,0 +1,57 @@
+# Prerequisites to run CStor-CSI in rancher based clusters
+
+## Intro
+CStor-CSI provides block volume support through the iSCSI protocol. Therefore, the iSCSI client(initiator) presence on all Kubernetes nodes is required.
+
+## Step to be performed on Rancher based K8s cluster
+
+- If you are using RancherOS as the operating system, you need to enable the iSCSI service and start iSCSI service on all the worker nodes.
+- If you are using Ubuntu or RHEL as the operating system, you need to
+    - Verify if iSCSI initiators are installed on all nodes.
+    - Add the extra_binds under Kubelet service in cluster YAML file to mount the iSCSI binary and configuration inside the kubelet.
+
+### iSCSI services On RancherOS
+To run iSCSI services, execute the following commands on each of the cluster hosts or nodes.
+```sh
+sudo ros s enable open-iscsi
+sudo ros s up open-iscsi
+```
+Run the below commands on all the nodes to make sure the below directories are persistent, by default these directories are ephemeral.
+```sh
+ros config set rancher.services.user-volumes.volumes  [/home:/home,/opt:/opt,/var/lib/kubelet:/var/lib/kubelet,/etc/kubernetes:/etc/kubernetes,/var/openebs]
+system-docker rm all-volumes
+reboot
+```
+
+### iSCSI services on RHEL or Ubuntu
+
+#### Step1:  Verify iSCSI initiator is installed and services are running
+
+Below commands are required to verify and install iscsi services on nodes
+
+| OPERATING SYSTEM | ISCSI PACKAGE         | COMMANDS                                               |
+|---------------------------------------------------------------------------------------------------|
+|                  | iscsi-initiator-utils | yum install iscsi-initiator-utils -y	                |
+| RHEL/CentOS      |                       | sudo systemctl enable --now iscsid                     |
+|                  |                       | modprobe iscsi_tcp                                     |
+|                  |                       | echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf     |
+|---------------------------------------------------------------------------------------------------|
+|                  |                       | sudo apt install open-iscsi                            |
+| Ununtu/ Debian   |                       | sudo systemctl enable --now iscsid                     |
+|                  |                       | modprobe iscsi_tcp                                     |
+|                  |                       | echo iscsi_tcp >/etc/modules-load.d/iscsi-tcp.conf     |
+
+#### Step2: Add extra_binds under kubelet service in cluster YAML
+
+After installing the initiator tool on your nodes, edit the YAML for your cluster, editing the kubelet configuration to mount the iSCSI binary and configuration, as shown in the sample below.
+
+```sh
+services:
+    kubelet: 
+      extra_binds: 
+        - "/etc/iscsi:/etc/iscsi"
+        - "/sbin/iscsiadm:/sbin/iscsiadm"
+        - "/var/lib/iscsi:/var/lib/iscsi"
+        - "/lib/modules"
+```
+**Note**: After performing prerequisites follow the steps mentioned [here](../quick.md) to deploy cStor in cluster.

--- a/docs/troubleshooting/rancher_prerequisite.md
+++ b/docs/troubleshooting/rancher_prerequisite.md
@@ -7,7 +7,7 @@ CStor-CSI provides block volume support through the iSCSI protocol. Therefore, t
 
 - If you are using RancherOS as the operating system, you need to enable the iSCSI service and start iSCSI service on all the worker nodes.
 - If you are using Ubuntu or RHEL as the operating system, you need to
-    - Verify if iSCSI initiators are installed on all nodes.
+    - Verify and install if iSCSI initiators are not installed on all the nodes.
     - Add the extra_binds under Kubelet service in cluster YAML file to mount the iSCSI binary and configuration inside the kubelet.
 
 ### iSCSI services On RancherOS
@@ -16,7 +16,7 @@ To run iSCSI services, execute the following commands on each of the cluster hos
 sudo ros s enable open-iscsi
 sudo ros s up open-iscsi
 ```
-Run the below commands on all the nodes to make sure the below directories are persistent, by default these directories are ephemeral.
+Run the below commands on all the nodes to make sure that the below directories are persistent, by default these directories are ephemeral.
 ```sh
 ros config set rancher.services.user-volumes.volumes  [/home:/home,/opt:/opt,/var/lib/kubelet:/var/lib/kubelet,/etc/kubernetes:/etc/kubernetes,/var/openebs]
 system-docker rm all-volumes
@@ -25,7 +25,7 @@ reboot
 
 ### iSCSI services on RHEL or Ubuntu
 
-#### Step1:  Verify iSCSI initiator is installed and services are running
+#### Step1:  Verify if iSCSI initiator is installed and services are running
 
 Below commands are required to verify and install iscsi services on nodes
 
@@ -36,8 +36,7 @@ Below commands are required to verify and install iscsi services on nodes
 
 #### Step2: Add extra_binds under kubelet service in cluster YAML
 
-After installing the initiator tool on your nodes, edit the YAML for your cluster, editing the kubelet configuration to mount the iSCSI binary and configuration, as shown in the sample below.
-
+After installing the iSCSI initiator on your nodes, bind them into the kubelet container by editing rancher cluster.yaml, as shown in the sample below.
 ```sh
 services:
     kubelet: 

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -3,3 +3,4 @@
 1. My nodes in Kubernetes cluster were replaced and the cStor pools are pending. How can I fix this? See [Node Replacement](migrate_pool_by_migrating_disks.md).
 2. Pool manager pods are running but it is not reconciling the CSPC state. See [Bad Disk](pool_operations_hung.md)
 3. Node and underlying disk in a Kubernetes cluster were lost and the cStor pools are pending. How can I fix this? see [Migrate cStor volume from lost pool](migrate_cstor_volume.md)
+4. How to run cStor-CSI on rancher based clusters? See [Rancher Prerequisites](rancher_prerequisite.md)


### PR DESCRIPTION
This PR adds prerequisite steps to install cStor-CSI
on rancher based Kubernetes cluster.

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>