### PR TITLE
fix(admission server): allow CRUD operations on CSPC if disk has zfs filesystem

### DIFF
--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -397,8 +397,10 @@ func validateBlockDevice(bd *openebsapis.BlockDevice, hostName string) error {
 		)
 	}
 	// In case of migration from SPC to CSPC there might be chances of blockdevice
-	// CR having FSType as "zfs_member" for cStor
-	// TODO: Check type of FS if blockdevice consumed by ZFS LOCALPV
+	// CR having FSType as "zfs_member" if devices are consumed by cStor. This FSType
+	// will present only if cStor is created on top of partitioned blockdevice.
+	// TODO: Check type of FS if blockdevice is consuming by ZFS LOCALPV. This case
+	// will be covered when we will check for blockdevice tag
 	if bd.Spec.FileSystem.Type != "" && bd.Spec.FileSystem.Type != "zfs_member" {
 		return errors.Errorf("block device has file system {%s}",
 			bd.Spec.FileSystem.Type,

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -396,7 +396,10 @@ func validateBlockDevice(bd *openebsapis.BlockDevice, hostName string) error {
 			"block device %q is in not in active state", bd.Name,
 		)
 	}
-	if bd.Spec.FileSystem.Type != "" {
+	// In case of migration from SPC to CSPC there might be chances of blockdevice
+	// CR having FSType as "zfs_member" for cStor
+	// TODO: Check type of FS if blockdevice consumed by ZFS LOCALPV
+	if bd.Spec.FileSystem.Type != "" && bd.Spec.FileSystem.Type != "zfs_member" {
 		return errors.Errorf("block device has file system {%s}",
 			bd.Spec.FileSystem.Type,
 		)


### PR DESCRIPTION
This PR fix the cStor admission server to perform
CRUD operations on CSPC when blockdevice has FS
type **zfs_member**. Why only "zfs_member" when
cStor pools are created fs type on the disk will
be shown as "zfs_member".

**NOTE**: This will be more helpful if users are
migrating from SPC based APIs to CSPC APIs.

**Sample Blockdevice Yaml with FS type**:
```sh
apiVersion: openebs.io/v1alpha1
  kind: BlockDevice
  metadata:
    creationTimestamp: "2020-07-29T09:15:30Z"
    finalizers:
    - openebs.io/bd-protection
    generation: 9
    labels:
      kubernetes.io/hostname: centos-worker-1
      ndm.io/blockdevice-type: blockdevice
      ndm.io/managed: "true"
    name: blockdevice-0b068bf489941cdb4c5133e5d911467b
    namespace: openebs
    resourceVersion: "26696242"
    selfLink: /apis/openebs.io/v1alpha1/namespaces/openebs/blockdevices/blockdevice-0b068bf489941cdb4c5133e5d911467b
    uid: 8d88f809-d1a8-4a19-9eea-fd008df7983b
  spec:
    capacity:
      logicalSectorSize: 512
      physicalSectorSize: 0
      storage: 26842480128
    details:
      compliance: SPC-
      deviceType: partition
      driveType: ""
      firmwareRevision: '1.0 '
      hardwareSectorSize: 0
      logicalBlockSize: 512
      model: Virtual_disk
      physicalBlockSize: 0
      serial: ""
      vendor: VMware
    devlinks:
    - kind: by-path
      links:
      - /dev/disk/by-path/pci-0000:03:00.0-sas-phy1-lun-0-part1
      - /dev/disk/by-path/pci-0000:03:00.0-sas-0x5000c29797f62dd1-lun-0-part1
    filesystem:
      fsType: zfs_member
    nodeAttributes:
      nodeName: centos-worker-1
    partitioned: "No"
    path: /dev/sdb1
  status:
    claimState: Unclaimed
    state: Active
```

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>