### PR TITLE
chore(validations): add check for BD tag presence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/openebs/api v1.12.1-0.20200729172328-4b0764aeaaf6
+	github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -387,6 +387,8 @@ github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/
 github.com/opencontainers/selinux v1.3.1-0.20190929122143-5215b1806f52/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
 github.com/openebs/api v1.12.1-0.20200729172328-4b0764aeaaf6 h1:3r1ByPvaWBJpLhGsJT67uNfxSV1/JfqWsr2Ca+zg2fQ=
 github.com/openebs/api v1.12.1-0.20200729172328-4b0764aeaaf6/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
+github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c h1:fZmO/A7BnxFAg9y1gjhtN6IG1ZBj0e0bLJTQtOI1Tk4=
+github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -413,6 +413,23 @@ func validateBlockDevice(bd *openebsapis.BlockDevice, hostName string) error {
 			bd.Labels[types.HostNameLabelKey],
 		)
 	}
+
+	if bd.Labels[types.HostNameLabelKey] != hostName {
+		return errors.Errorf(
+			"block device %s doesn't belongs to node %s",
+			bd.Name,
+			bd.Labels[types.HostNameLabelKey],
+		)
+	}
+
+	if v, found := bd.Labels[types.BlockDeviceTagLabelKey]; found {
+		return errors.Errorf(
+			"block device %s is tagged with a value %s and cannot be used",
+			bd.Name,
+			v,
+		)
+	}
+
 	return nil
 }
 

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -413,15 +413,7 @@ func validateBlockDevice(bd *openebsapis.BlockDevice, hostName string) error {
 			bd.Labels[types.HostNameLabelKey],
 		)
 	}
-
-	if bd.Labels[types.HostNameLabelKey] != hostName {
-		return errors.Errorf(
-			"block device %s doesn't belongs to node %s",
-			bd.Name,
-			bd.Labels[types.HostNameLabelKey],
-		)
-	}
-
+	
 	if v, found := bd.Labels[types.BlockDeviceTagLabelKey]; found {
 		return errors.Errorf(
 			"block device %s is tagged with a value %s and cannot be used",

--- a/vendor/github.com/openebs/api/pkg/apis/types/types.go
+++ b/vendor/github.com/openebs/api/pkg/apis/types/types.go
@@ -58,6 +58,11 @@ const (
 	// PersistentVolumeLabelKey label key set in all cstorvolume replicas of a
 	// given volume
 	PersistentVolumeLabelKey = "openebs.io/persistent-volume"
+
+	// BlockDeviceTagLabelKey is the key to fetch tag of a block
+	// device.
+	// For more info : https://github.com/openebs/node-disk-manager/pull/400
+	BlockDeviceTagLabelKey = "openebs.io/block-device-tag"
 )
 
 const (

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openebs/api v1.12.1-0.20200729172328-4b0764aeaaf6
+# github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c
 github.com/openebs/api/pkg/apis/cstor
 github.com/openebs/api/pkg/apis/cstor/v1
 github.com/openebs/api/pkg/apis/openebs.io


### PR DESCRIPTION
BD can be tagged in order to reserve it to be used later or by other storage
engine. If a tag is found in BD then it should not be used by cstor. This commit
adds a check for this. If a tag is found in BD and is used in CSPC for cStor
pool provisioning then the cStor webhook server will reject the request.

**NOTE:** This PR https://github.com/openebs/api/pull/62/files needs to be merged first and then a rebase will be required for the current PR.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>