### PR TITLE
feat(tests): add integration test cases for changing the policies on CVC dynamically

### DIFF
--- a/tests/cstorvolume/provisioing/provisioning_test.go
+++ b/tests/cstorvolume/provisioing/provisioning_test.go
@@ -27,18 +27,21 @@ import (
 	"github.com/openebs/cstor-operators/tests/pkg/cstorvolumeconfig/cvcspecbuilder"
 	"github.com/openebs/cstor-operators/tests/pkg/k8sclient"
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 var (
 	// openebsNamespace defines namespace where openebs is installed
 	openebsNamespace = "openebs"
-	// cspc will holds the CStorPoolCluster
-	cspc *cstorapis.CStorPoolCluster
-	// specBuilder for building the CSPC spec
-	specBuilder *cspcspecbuilder.CSPCSpecBuilder
+	// cspcSpecBuilder for building the CSPC spec
+	cspcSpecBuilder *cspcspecbuilder.CSPCSpecBuilder
 	// cvcSpecBuilder for building the CVC Spec
 	cvcSpecBuilder *cvcspecbuilder.CVCSpecBuilder
+	// cspc will holds the CStorPoolCluster
+	cspc *cstorapis.CStorPoolCluster
 )
 
 /*
@@ -50,6 +53,10 @@ This test file covers following test cases :
 var _ = Describe("Volume Provisioning Tests", func() {
 	CSIVolumeProvisioningTest()
 	ProvisionVolumeWithReplicaCountMoreThanAvailablePools()
+	CSIVolumeProvisioningTestWithResourceLimits()
+	CSIVolumeProvisioningTestWithTolerations()
+	ProvisionVolumeWithPriorityClass()
+	ProvisionVolumeAndUpdateTunables()
 })
 
 func CSIVolumeProvisioningTest() {
@@ -66,13 +73,17 @@ func CSIVolumeProvisioningTest() {
 
 		Context("Provision CStor-CSI volume", func() {
 			It("Should provision volume and PVC should bound to PV", func() {
+				Expect(cspc).NotTo(BeNil(), "cstor-stripe CSPC is not created successfully")
+				Expect(cvcSpecBuilder).NotTo(BeNil(), "cvcspec builder is not initilized")
 				ProvisionCSIVolume(pvcName, testNS, scName)
+				VerifyCStorVolumeResourcesStatus(pvcName, testNS)
 			})
 		})
 
 		Context("Verify Status of CStorVolume related resources", func() {
 			Specify("no error should be returned and all the resources must be healthy", func() {
 				VerifyCStorVolumeResourcesStatus(pvcName, testNS)
+				Expect(cvcSpecBuilder.CVC).NotTo(BeNil(), "cvc in spec builder is not initilized")
 			})
 		})
 
@@ -84,6 +95,7 @@ func CSIVolumeProvisioningTest() {
 
 		Context("Deleting PVC Namespace", func() {
 			Specify("no error should occur during deletion of namespace", func() {
+				Expect(cspc).NotTo(BeNil(), "cstor-stripe CSPC is not created successfully")
 				err := cstorsuite.client.KubeClientSet.CoreV1().Namespaces().Delete(testNS, &metav1.DeleteOptions{})
 				Expect(err).To(BeNil())
 			})
@@ -91,6 +103,356 @@ func CSIVolumeProvisioningTest() {
 
 		Context("Deprovisioning cspc", func() {
 			Specify("no error should be returned during pool deprovisioning", func() {
+				// if CSPC creation is failed no need to delete CSPC
+				if cspc == nil {
+					return
+				}
+				DeProvisionCSPC(cspc)
+			})
+		})
+	})
+}
+
+// CSIVolumeProvisioningTestWithResourceLimits will create volume and perform following steps
+// 1. Add resource limits to CVC and verify whether resource limits are propogated to the target pod
+// 2. Remove resource limits to CVC and verify whether resource limits are removed from target pod
+func CSIVolumeProvisioningTestWithResourceLimits() {
+	testNS := "test-provisioning-resource-limits"
+	pvcName := "pvc-vol-resource-limits"
+	scName := "cstor-provision-sc-resource-limits"
+
+	Describe("Intantiating dynamic Volume resource limits tests", func() {
+		Context("Provision pools using CSPC", func() {
+			It("should provision pools and pools should be marked as Healthy", func() {
+				ProvisionCSPC("cstor-stripe-for-resource-limits", openebsNamespace, "stripe", 1)
+			})
+		})
+
+		Context("Provision CStor-CSI volume and add and remove resource limits dynamically", func() {
+			It("Should propogated to volume manager pod", func() {
+
+				Expect(cspc).NotTo(BeNil(), "cstor-stripe-with-resource-limits CSPC is not created successfully")
+				Expect(cvcSpecBuilder).NotTo(BeNil(), "cvcspec builder is not initilized")
+
+				// resourcelimits for main container
+				resourceLimits := &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList(
+						map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: resource.MustParse("500Mi"),
+							corev1.ResourceCPU:    resource.MustParse("0"),
+						},
+					),
+					Limits: corev1.ResourceList(
+						map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: resource.MustParse("1Gi"),
+							corev1.ResourceCPU:    resource.MustParse("0"),
+						},
+					),
+				}
+
+				// resourcelimits for side car container
+				auxResourceLimits := &corev1.ResourceRequirements{
+					Requests: corev1.ResourceList(
+						map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: resource.MustParse("500Mi"),
+							corev1.ResourceCPU:    resource.MustParse("0"),
+						},
+					),
+					Limits: corev1.ResourceList(
+						map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceMemory: resource.MustParse("700Mi"),
+							corev1.ResourceCPU:    resource.MustParse("0"),
+						},
+					),
+				}
+
+				// Provision cStor CSI volume
+				ProvisionCSIVolume(pvcName, testNS, scName)
+				// Verify whether all the cStor volumes created
+				VerifyCStorVolumeResourcesStatus(pvcName, testNS)
+
+				// add resource limits on CVC.Spec.Policy
+				cvcSpecBuilder.SetResourceLimits(resourceLimits, auxResourceLimits)
+				// updatedCVC, err := cstorsuite.client.PatchCVCResourceLimits(cvcSpecBuilder.CVC, resourceLimits, auxResourceLimits)
+				updatedCVC, err := cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+				Expect(err).To(BeNil(), "failed to patch cvc with resource limits")
+				cvcSpecBuilder.SetCVCSpec(updatedCVC)
+				// Verify whether resource limits are propogated to volume manager pod
+				klog.Infof("Waiting for volumemanager to have both resource limits")
+				err = cstorsuite.client.WaitForVolumeManagerResourceLimits(
+					cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace,
+					*resourceLimits, *auxResourceLimits, k8sclient.VolumeMangerConfigTimeout, 5*time.Second)
+				Expect(err).To(BeNil(), "volume manger should have specified limits")
+
+				// remove auxresource limits alone
+				cvcSpecBuilder.SetResourceLimits(resourceLimits, nil)
+				//	updatedCVC, err = cstorsuite.client.PatchCVCResourceLimits(cvcSpecBuilder.CVC, resourceLimits, nil)
+				updatedCVC, err = cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+				Expect(err).To(BeNil(), "failed to patch cvc without auxresource limits")
+				klog.Infof("Resource limits %+v - %+v", updatedCVC.Spec.Policy.Target.Resources, updatedCVC.Spec.Policy.Target.AuxResources)
+				cvcSpecBuilder.SetCVCSpec(updatedCVC)
+				// Verify whether resource limits are propogated to volume manager pod
+				klog.Infof("Waiting for volumemanager to have resource limits alone")
+				err = cstorsuite.client.WaitForVolumeManagerResourceLimits(
+					cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace,
+					*resourceLimits, corev1.ResourceRequirements{}, k8sclient.VolumeMangerConfigTimeout, 5*time.Second)
+				Expect(err).To(BeNil(), "volume manger should have specified limits")
+
+				// remove resource limits on main container
+				cvcSpecBuilder.SetResourceLimits(nil, nil)
+				updatedCVC, err = cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+				//updatedCVC, err = cstorsuite.client.PatchCVCResourceLimits(cvcSpecBuilder.CVC, nil, nil)
+				Expect(err).To(BeNil(), "failed to patch cvc without auxresource limits")
+				cvcSpecBuilder.SetCVCSpec(updatedCVC)
+				// Verify whether resource limits are propogated to volume manager pod
+				klog.Infof("Waiting for volumemanager not to have any resource limits")
+				err = cstorsuite.client.WaitForVolumeManagerResourceLimits(
+					cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace,
+					corev1.ResourceRequirements{}, corev1.ResourceRequirements{},
+					k8sclient.VolumeMangerConfigTimeout, 5*time.Second)
+				Expect(err).To(BeNil(), "volume manger should have specified limits")
+
+				DeProvisionVolume(pvcName, testNS, scName)
+
+				err = cstorsuite.client.KubeClientSet.CoreV1().Namespaces().Delete(testNS, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("Deprovisioning cspc", func() {
+			Specify("no error should be returned during pool deprovisioning", func() {
+				// if CSPC creation is failed no need to delete CSPC
+				if cspc == nil {
+					return
+				}
+				DeProvisionCSPC(cspc)
+			})
+		})
+	})
+
+}
+
+// CSIVolumeProvisioningTestWithTolerations will create volume and perform following steps
+// 1. Add tolerations to CVC and verify whether tolerations are propogated to the target deployment
+// 2. Remove tolerations from CVC and verify whether tolerations are removed from target deployment
+// NOTE: Test will verify toleration on deployment because adding node will cause some problem
+func CSIVolumeProvisioningTestWithTolerations() {
+	testNS := "test-provisioning-tolerations"
+	pvcName := "pvc-vol-toleratations"
+	scName := "cstor-provision-sc-tolerations"
+
+	Describe("Intantiating dynamic Volume provisioning and add tolerations dynamically", func() {
+		Context("Provision pools using CSPC", func() {
+			It("should provision pools and pools should be marked as Healthy", func() {
+				ProvisionCSPC("cstor-stripe-for-tolerations", openebsNamespace, "stripe", 1)
+			})
+		})
+
+		Context("Provision CStor-CSI volume and add and remove tolertions dynamically", func() {
+			It("Should propogated to volume manager pod", func() {
+
+				Expect(cspc).NotTo(BeNil(), "cstor-stripe-for-toleration CSPC is not created successfully")
+				Expect(cvcSpecBuilder).NotTo(BeNil(), "cvcspec builder is not initilized")
+
+				tolerations := []corev1.Toleration{
+					{
+						Key:      "test-tolerations",
+						Operator: corev1.TolerationOpEqual,
+						Value:    "value",
+						Effect:   "NoSchedule",
+					},
+				}
+
+				// Provision cStor CSI volume
+				ProvisionCSIVolume(pvcName, testNS, scName)
+				// Verify whether all the cStor volumes created
+				VerifyCStorVolumeResourcesStatus(pvcName, testNS)
+
+				// add tolerations on CVC.Spec.Policy
+				cvcSpecBuilder.SetTolerations(tolerations)
+				updatedCVC, err := cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+				Expect(err).To(BeNil(), "failed to patch cvc with tolerations")
+				cvcSpecBuilder.SetCVCSpec(updatedCVC)
+				// Verify whether tolerations are propogated to volume manager deployment
+				klog.Infof("Waiting for cstor volumemanager deployment to have tolerations")
+				err = cstorsuite.client.WaitForVolumeManagerTolerations(
+					cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace,
+					tolerations, k8sclient.VolumeMangerConfigTimeout, 5*time.Second)
+				Expect(err).To(BeNil(), "volume manger should have specified limits")
+
+				// remove tolerations on CVC.Spec.Policy
+				cvcSpecBuilder.SetTolerations([]corev1.Toleration{})
+				updatedCVC, err = cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+				Expect(err).To(BeNil(), "failed to patch cvc with tolerations")
+				cvcSpecBuilder.SetCVCSpec(updatedCVC)
+				// Verify whether tolerations are propogated to volume manager deployment
+				klog.Infof("Waiting for cstor volumemanager deployment to have tolerations")
+				err = cstorsuite.client.WaitForVolumeManagerTolerations(
+					cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace,
+					[]corev1.Toleration{}, k8sclient.VolumeMangerConfigTimeout, 5*time.Second)
+				Expect(err).To(BeNil(), "volume manger should have specified limits")
+				DeProvisionVolume(pvcName, testNS, scName)
+
+				err = cstorsuite.client.KubeClientSet.CoreV1().Namespaces().Delete(testNS, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("Deprovisioning cspc", func() {
+			Specify("no error should be returned during pool deprovisioning", func() {
+				// if CSPC creation is failed no need to delete CSPC
+				if cspc == nil {
+					return
+				}
+				DeProvisionCSPC(cspc)
+			})
+		})
+	})
+}
+
+func ProvisionVolumeWithPriorityClass() {
+	testNS := "test-provisioning-priority-class"
+	pvcName := "pvc-vol-priority-class"
+	scName := "cstor-provision-sc-priority"
+
+	Describe("Provisioning cStor Volume and dynamically adding priority class tests", func() {
+		Context("Provision pools using CSPC", func() {
+			It("should provision pools and pools should be marked as Healthy", func() {
+				ProvisionCSPC("cstor-stripe-for-priority", openebsNamespace, "stripe", 1)
+			})
+		})
+
+		Context("Provision CStor-CSI volume and add and remove priority class dynamically", func() {
+			It("Should propogated to volume manager pod", func() {
+
+				Expect(cspc).NotTo(BeNil(), "cstor-stripe-for-priority CSPC is not created successfully")
+				Expect(cvcSpecBuilder).NotTo(BeNil(), "cvcspec builder is not initilized")
+
+				priorityClass := &schedulingv1.PriorityClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "priority-class",
+					},
+					Value:         100,
+					GlobalDefault: false,
+				}
+
+				// Create Priority class
+				priorityClassObj, err := cstorsuite.client.KubeClientSet.SchedulingV1().PriorityClasses().Create(priorityClass)
+				Expect(err).To(BeNil(), "failed to create %s priority class", priorityClass.Name)
+
+				// Provision cStor CSI volume
+				ProvisionCSIVolume(pvcName, testNS, scName)
+				// Verify whether all the cStor volumes created
+				VerifyCStorVolumeResourcesStatus(pvcName, testNS)
+
+				// add priority class to CVC.Spec.Policy
+				cvcSpecBuilder.SetPriorityClass(priorityClass.Name)
+				updatedCVC, err := cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+				Expect(err).To(BeNil(), "failed to patch cvc with priority class")
+				cvcSpecBuilder.SetCVCSpec(updatedCVC)
+				// Verify whether priority class is propogated to volume manager
+				klog.Infof("Waiting for cstor volumemanager deployment to have priority class")
+				err = cstorsuite.client.WaitForVolumeManagerPriorityClass(
+					cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace,
+					priorityClassObj.Name, k8sclient.VolumeMangerConfigTimeout, 5*time.Second)
+				Expect(err).To(BeNil(), "volume manger should have specified priority class")
+
+				// remove priority on CVC.Spec.Policy
+				cvcSpecBuilder.SetPriorityClass("")
+				updatedCVC, err = cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+				Expect(err).To(BeNil(), "failed to remove priority class from CVC")
+				cvcSpecBuilder.SetCVCSpec(updatedCVC)
+				// Verify whether priority class is propogated to volume manager deployment
+				klog.Infof("Waiting for cstor volumemanager to have priority class")
+				err = cstorsuite.client.WaitForVolumeManagerPriorityClass(
+					cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace,
+					"", k8sclient.VolumeMangerConfigTimeout, 5*time.Second)
+				Expect(err).To(BeNil(), "volume manger should have specified priority class")
+
+				DeProvisionVolume(pvcName, testNS, scName)
+
+				// Delete Priority class
+				err = cstorsuite.client.KubeClientSet.SchedulingV1().PriorityClasses().Delete(priorityClass.Name, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil(), "failed to delete %s priority class", priorityClass.Name)
+
+				err = cstorsuite.client.KubeClientSet.CoreV1().Namespaces().Delete(testNS, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			})
+		})
+		Context("Deprovisioning cspc", func() {
+			Specify("no error should be returned during pool deprovisioning", func() {
+				if cspc == nil {
+					return
+				}
+				DeProvisionCSPC(cspc)
+			})
+		})
+	})
+}
+
+func ProvisionVolumeAndUpdateTunables() {
+	testNS := "test-provisioning-tunables"
+	pvcName := "pvc-vol-tunables"
+	scName := "cstor-provision-sc-tunables"
+
+	Describe("Provisioning cStor Volume and dynamically update tunables", func() {
+		Context("Provision pools using CSPC", func() {
+			It("should provision pools and pools should be marked as Healthy", func() {
+				ProvisionCSPC("cstor-stripe-tunables", openebsNamespace, "stripe", 1)
+			})
+		})
+
+		Context("Provision CStor-CSI volume and update tunables dynamically", func() {
+			It("Should propogated to volume manager pod", func() {
+
+				Expect(cspc).NotTo(BeNil(), "cstor-stripe-tunables CSPC is not created successfully")
+				Expect(cvcSpecBuilder).NotTo(BeNil(), "cvcspec builder is not initilized")
+
+				// Provision cStor CSI volume
+				ProvisionCSIVolume(pvcName, testNS, scName)
+				// Verify whether all the cStor volumes created
+				VerifyCStorVolumeResourcesStatus(pvcName, testNS)
+
+				// add tunables to CVC.Spec.Policy
+				cvcSpecBuilder.SetLuWorkers(8)
+				cvcSpecBuilder.SetQueueDepth("64")
+				updatedCVC, err := cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+				Expect(err).To(BeNil(), "failed to patch cvc with tunables")
+				cvcSpecBuilder.SetCVCSpec(updatedCVC)
+				// Verify whether tunables are propogated to volume manager
+				klog.Infof("Waiting for cstor volumemanager to have tunables")
+				err = cstorsuite.client.WaitForVolumeManagerTunables(
+					cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace,
+					cvcSpecBuilder.CVC.Spec.Policy.Target.IOWorkers, cvcSpecBuilder.CVC.Spec.Policy.Target.QueueDepth,
+					k8sclient.VolumeMangerConfigTimeout, 5*time.Second)
+				Expect(err).To(BeNil(), "volume manger should have specified tunables")
+
+				// Add node selector dynamically
+				nodeLabels := map[string]string{}
+				for _, labels := range cspcSpecBuilder.CSPCCache.NodeLabels {
+					nodeLabels = labels
+					break
+				}
+				cvcSpecBuilder.SetNodeSelector(nodeLabels)
+				updatedCVC, err = cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+				cvcSpecBuilder.SetCVCSpec(updatedCVC)
+				Expect(err).To(BeNil(), "failed to patch cvc with nodeSelector details")
+				klog.Infof("Waiting for cstor volumemanager to have nodeSelector changes")
+				err = cstorsuite.client.WaitForVolumeManagerNodeSelector(
+					cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace,
+					nodeLabels, k8sclient.VolumeMangerConfigTimeout, 5*time.Second)
+
+				DeProvisionVolume(pvcName, testNS, scName)
+
+				err = cstorsuite.client.KubeClientSet.CoreV1().Namespaces().Delete(testNS, &metav1.DeleteOptions{})
+				Expect(err).To(BeNil())
+			})
+		})
+		Context("Deprovisioning cspc", func() {
+			Specify("no error should be returned during pool deprovisioning", func() {
+				if cspc == nil {
+					return
+				}
 				DeProvisionCSPC(cspc)
 			})
 		})
@@ -103,6 +465,7 @@ func ProvisionVolumeWithReplicaCountMoreThanAvailablePools() {
 	testNS := "test-provisioning"
 	pvcName := "pvc-with-more-replicas"
 	scName := "sc-with-more-replicas"
+
 	Describe("Intantiating Volume provisioing test with replica count more than available pools", func() {
 		Context("Provision pools using CSPC", func() {
 			It("should provision pools and pools should be marked as Healthy", func() {
@@ -111,6 +474,10 @@ func ProvisionVolumeWithReplicaCountMoreThanAvailablePools() {
 		})
 		Context("Provision CStor-CSI volume", func() {
 			It("Shouldn't provision volume and CVC should be in Pending state", func() {
+				if cspc == nil {
+					klog.Errorf("cstor-stripe-more-replicas CSPC is not created")
+					return
+				}
 				// Build parameters required for provisioning volume
 				scParameters := map[string]string{
 					"cas-type":         "cstor",
@@ -158,6 +525,9 @@ func ProvisionVolumeWithReplicaCountMoreThanAvailablePools() {
 
 		Context("Deprovisioning cspc", func() {
 			Specify("no error should be returned during pool deprovisioning", func() {
+				if cspc == nil {
+					return
+				}
 				DeProvisionCSPC(cspc)
 			})
 		})

--- a/tests/cstorvolume/provisioing/provisioning_utils.go
+++ b/tests/cstorvolume/provisioing/provisioning_utils.go
@@ -163,6 +163,10 @@ func DeProvisionVolume(pvcName, pvcNamespace, scName string) {
 		Expect(err).To(BeNil())
 	}
 
+	err = cstorsuite.client.WaitForPersistentVolumeClaimDeletion(pvcName, pvcNamespace, k8sclient.Poll, k8sclient.ClaimDeletingTimeout)
+	Expect(err).To(BeNil())
+
+
 	err = cstorsuite.client.KubeClientSet.
 		StorageV1().
 		StorageClasses().
@@ -176,7 +180,7 @@ func DeProvisionVolume(pvcName, pvcNamespace, scName string) {
 		return
 	}
 
-	err = cstorsuite.client.WaitForCStorVolumeDeleted(
+	err = cstorsuite.client.WaitForCStorVolumeDeletion(
 		pvc.Spec.VolumeName, openebsNamespace, k8sclient.Poll, k8sclient.CVDeletingTimeout)
 	Expect(err).To(BeNil())
 
@@ -186,10 +190,10 @@ func DeProvisionVolume(pvcName, pvcNamespace, scName string) {
 
 	err = cstorsuite.client.WaitForCVRCountEventually(
 		pvc.Spec.VolumeName, openebsNamespace, 0,
-		k8sclient.Poll, k8sclient.CVRPhaseTimeout, cstorapis.IsCVRHealthy)
+		k8sclient.Poll, k8sclient.CVRPhaseTimeout)
 	Expect(err).To(BeNil())
 
-	err = cstorsuite.client.WaitForCStorVolumeConfigDeleted(
+	err = cstorsuite.client.WaitForCStorVolumeConfigDeletion(
 		pvc.Spec.VolumeName, openebsNamespace, k8sclient.Poll, k8sclient.CVCDeletingTimeout)
 	Expect(err).To(BeNil())
 

--- a/tests/pkg/k8sclient/cv_util.go
+++ b/tests/pkg/k8sclient/cv_util.go
@@ -59,9 +59,9 @@ func (client *Client) WaitForCStorVolumePhase(
 	return errors.Errorf("CStorVolume %s not at all in phase %s", cvcName, expectedPhase)
 }
 
-// WaitForCStorVolumeDeleted waits for a CStorVolume
+// WaitForCStorVolumeDeletion waits for a CStorVolume
 // to be removed from the system until timeout occurs, whichever comes first
-func (client *Client) WaitForCStorVolumeDeleted(cvName, cvNamespace string, poll, timeout time.Duration) error {
+func (client *Client) WaitForCStorVolumeDeletion(cvName, cvNamespace string, poll, timeout time.Duration) error {
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
 		_, err := client.GetCV(cvName, cvNamespace)
 		if err != nil {

--- a/tests/pkg/k8sclient/cvc_util.go
+++ b/tests/pkg/k8sclient/cvc_util.go
@@ -76,9 +76,9 @@ func (client *Client) WaitForCStorVolumeReplicaPools(
 	return errors.Errorf("CStorVolumeConfig %s replicas are not yet present in desired pools", cvcName)
 }
 
-// WaitForCStorVolumeConfigDeleted waits for a CStorVolumeConfig
+// WaitForCStorVolumeConfigDeletion waits for a CStorVolumeConfig
 // to be removed from the system until timeout occurs, whichever comes first
-func (client *Client) WaitForCStorVolumeConfigDeleted(cvcName, cvcNamespace string, poll, timeout time.Duration) error {
+func (client *Client) WaitForCStorVolumeConfigDeletion(cvcName, cvcNamespace string, poll, timeout time.Duration) error {
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
 		_, err := client.GetCVC(cvcName, cvcNamespace)
 		if err != nil {

--- a/tests/pkg/k8sclient/pvc_util.go
+++ b/tests/pkg/k8sclient/pvc_util.go
@@ -62,7 +62,7 @@ func (client *Client) WaitForPersistentVolumeClaimPhase(
 		if pvcObj.Status.Phase == expectedPhase {
 			return nil
 		}
-		klog.Infof("PersistentVolumeClaim %s found and phase=%s (%v)", pvcName, expectedPhase, time.Since(start))
+		klog.Infof("PersistentVolumeClaim %s found and phase=%s (%v)", pvcName, pvcObj.Status.Phase, time.Since(start))
 	}
 	return errors.Errorf("PersistentVolumeClaim %s not at all in phase %s", pvcName, expectedPhase)
 }

--- a/tests/pkg/k8sclient/pvc_util.go
+++ b/tests/pkg/k8sclient/pvc_util.go
@@ -72,9 +72,9 @@ func (client *Client) GetPVC(pvcName, pvcNamespace string) (*corev1.PersistentVo
 	return client.KubeClientSet.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(pvcName, metav1.GetOptions{})
 }
 
-// WaitForPersistentVolumeClaimDeleted waits for a PersistentVolumeClaim
+// WaitForPersistentVolumeClaimDeletion waits for a PersistentVolumeClaim
 // to be removed from the system until timeout occurs, whichever comes first
-func (client *Client) WaitForPersistentVolumeClaimDeleted(pvcName, pvcNamespace string, poll, timeout time.Duration) error {
+func (client *Client) WaitForPersistentVolumeClaimDeletion(pvcName, pvcNamespace string, poll, timeout time.Duration) error {
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(poll) {
 		_, err := client.GetPVC(pvcName, pvcNamespace)
 		if err != nil {


### PR DESCRIPTION
This PR adds covers the following integration test cases:
- Updating (includes adding and removing) resource requirements on CVC.
- Adding toleration on CVC.
- Adding priority class name on CVC.
- Update luworkers and queuedepth values on CVC.
- Updating CVC with a target node selector.

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>