### PR TITLE
test(cspc): add cspc tunables test

### DIFF
--- a/tests/pkg/cspc/cspcspecbuilder/specbuilder.go
+++ b/tests/pkg/cspc/cspcspecbuilder/specbuilder.go
@@ -22,6 +22,7 @@ import (
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	"github.com/openebs/cstor-operators/tests/pkg/cache/cspccache"
 	"github.com/openebs/cstor-operators/tests/pkg/infra"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 )
 
@@ -101,6 +102,101 @@ type ReplacementTracer struct {
 
 func NewReplacementTracer() *ReplacementTracer {
 	return &ReplacementTracer{}
+}
+
+// AddResourceLimits adds resource limits to all the pools of the CSPC
+func (c *CSPCSpecBuilder) AddResourceLimits(resources *corev1.ResourceRequirements) *CSPCSpecBuilder {
+	for i := 0; i < len(c.CSPC.Spec.Pools); i++ {
+		c.AddResourceLimitsAtPos(resources, i)
+	}
+	return c
+}
+
+// AddResourceLimitsAtPos adds resource limits to the CSPC at a given position
+func (c *CSPCSpecBuilder) AddResourceLimitsAtPos(resources *corev1.ResourceRequirements, atPoolPos int) *CSPCSpecBuilder {
+	if atPoolPos >= len(c.CSPC.Spec.Pools) {
+		klog.Warningf("Could not add resource and limit to pool spec"+
+			"as length of pool spec is %s and pos to add is %s", len(c.CSPC.Spec.Pools), atPoolPos)
+		return c
+	}
+	c.CSPC.Spec.Pools[atPoolPos].PoolConfig.WithResources(resources)
+	return c
+}
+
+// AddTolerations adds tolerations to all the pools of the CSPC
+func (c *CSPCSpecBuilder) AddTolerations(tolerations []corev1.Toleration) *CSPCSpecBuilder {
+	for i := 0; i < len(c.CSPC.Spec.Pools); i++ {
+		c.AddTolerationsAtPos(tolerations, i)
+	}
+	return c
+}
+
+// AddTolerationsAtPos adds tolerations to the CSPC at a given position
+func (c *CSPCSpecBuilder) AddTolerationsAtPos(tolerations []corev1.Toleration, atPoolPos int) *CSPCSpecBuilder {
+	if atPoolPos >= len(c.CSPC.Spec.Pools) {
+		klog.Warningf("Could not add tolerations to pool spec"+
+			"as length of pool spec is %s and pos to add is %s", len(c.CSPC.Spec.Pools), atPoolPos)
+		return c
+	}
+	c.CSPC.Spec.Pools[atPoolPos].PoolConfig.WithTolerations(tolerations)
+	return c
+}
+
+// AddPriorityClass adds priority class to all the pools of the CSPC
+func (c *CSPCSpecBuilder) AddPriorityClass(priorityClass *string) *CSPCSpecBuilder {
+	for i := 0; i < len(c.CSPC.Spec.Pools); i++ {
+		c.AddPriorityClassAtPos(priorityClass, i)
+	}
+	return c
+}
+
+// AddPriorityClassAtPos adds priority class to the CSPC at a given position
+func (c *CSPCSpecBuilder) AddPriorityClassAtPos(priorityClass *string, atPoolPos int) *CSPCSpecBuilder {
+	if atPoolPos >= len(c.CSPC.Spec.Pools) {
+		klog.Warningf("Could not add priority class to pool spec"+
+			"as length of pool spec is %s and pos to add is %s", len(c.CSPC.Spec.Pools), atPoolPos)
+		return c
+	}
+	c.CSPC.Spec.Pools[atPoolPos].PoolConfig.WithPriorityClassName(priorityClass)
+	return c
+}
+
+// AddCompression adds compression to all the pool of the CSPC
+func (c *CSPCSpecBuilder) AddCompression(compression string) *CSPCSpecBuilder {
+	for i := 0; i < len(c.CSPC.Spec.Pools); i++ {
+		c.AddCompressionAtPos(compression, i)
+	}
+	return c
+}
+
+// AddCompressionAtPos adds compression to the CSPC at a given position
+func (c *CSPCSpecBuilder) AddCompressionAtPos(compression string, atPoolPos int) *CSPCSpecBuilder {
+	if atPoolPos >= len(c.CSPC.Spec.Pools) {
+		klog.Warningf("Could not add compression to pool spec"+
+			"as length of pool spec is %s and pos to add is %s", len(c.CSPC.Spec.Pools), atPoolPos)
+		return c
+	}
+	c.CSPC.Spec.Pools[atPoolPos].PoolConfig.Compression = compression
+	return c
+}
+
+// AddRoThreshold adds Read only threshold to all the pools of the CSPC
+func (c *CSPCSpecBuilder) AddRoThreshold(roLimit *int) *CSPCSpecBuilder {
+	for i := 0; i < len(c.CSPC.Spec.Pools); i++ {
+		c.AddRoThresholdAtPos(roLimit, i)
+	}
+	return c
+}
+
+// AddRoThresholdAtPos adds Read only threshold to the CSPC at a given position
+func (c *CSPCSpecBuilder) AddRoThresholdAtPos(roLimit *int, atPoolPos int) *CSPCSpecBuilder {
+	if atPoolPos >= len(c.CSPC.Spec.Pools) {
+		klog.Warningf("Could not add RO threshold to pool spec"+
+			"as length of pool spec is %s and pos to add is %s", len(c.CSPC.Spec.Pools), atPoolPos)
+		return c
+	}
+	c.CSPC.Spec.Pools[atPoolPos].PoolConfig.WithROThresholdLimit(roLimit)
+	return c
 }
 
 // ReplaceBlockDevice replaces a block device at the provided position in the CSPC

--- a/tests/pkg/k8sclient/cspc_util.go
+++ b/tests/pkg/k8sclient/cspc_util.go
@@ -17,14 +17,15 @@ limitations under the License.
 package k8sclient
 
 import (
-	"time"
-
 	. "github.com/onsi/gomega"
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	"github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
 	"github.com/openebs/api/pkg/apis/types"
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"time"
 )
 
 const maxRetry = 30
@@ -168,4 +169,160 @@ func (client *Client) GetCSPC(cspcName, cspcNamespace string) *cstor.CStorPoolCl
 	cspc, err := client.OpenEBSClientSet.CstorV1().CStorPoolClusters(cspcNamespace).Get(cspcName, metav1.GetOptions{})
 	Expect(err).To(BeNil())
 	return cspc
+}
+
+// HasResourceLimitOnCSPIEventually ...
+func (client *Client) HasResourceLimitOnCSPIEventually(
+	cspcName, cspcNamespace string, expectedResource *corev1.ResourceRequirements) bool {
+	for i := 0; i < (maxRetry + 100); i++ {
+		resourceLimitMatches := true
+		cspiList := client.GetCSPIList(cspcName, cspcNamespace)
+		for _, v := range cspiList.Items {
+			if !reflect.DeepEqual(v.Spec.PoolConfig.Resources, expectedResource) {
+				resourceLimitMatches = false
+			}
+		}
+		if resourceLimitMatches {
+			return resourceLimitMatches
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return false
+}
+
+// HasResourceLimitOnPoolManagerEventually ...
+func (client *Client) HasResourceLimitOnPoolManagerEventually(
+	cspcName, cspcNamespace string, expectedResource *corev1.ResourceRequirements) bool {
+	for i := 0; i < (maxRetry + 100); i++ {
+		resourceLimitMatches := true
+		pmList := client.GetPoolManagerList(cspcName, cspcNamespace)
+		for _, pm := range pmList.Items {
+			for _, container := range pm.Spec.Template.Spec.Containers {
+				if container.Name == "cstor-pool" {
+					if !reflect.DeepEqual(container.Resources, *expectedResource) {
+						resourceLimitMatches = false
+					}
+				}
+			}
+		}
+		if resourceLimitMatches {
+			return resourceLimitMatches
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return false
+}
+
+// HasTolerationsOnCSPIEventually ...
+func (client *Client) HasTolerationsOnCSPIEventually(
+	cspcName, cspcNamespace string, tolerations []corev1.Toleration) bool {
+	for i := 0; i < (maxRetry + 100); i++ {
+		tolerationsMatches := true
+		cspiList := client.GetCSPIList(cspcName, cspcNamespace)
+		for _, v := range cspiList.Items {
+			if !reflect.DeepEqual(v.Spec.PoolConfig.Tolerations, tolerations) {
+				tolerationsMatches = false
+			}
+		}
+		if tolerationsMatches {
+			return tolerationsMatches
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return false
+}
+
+// HasTolerationsOnPoolManagerEventually ...
+func (client *Client) HasTolerationsOnPoolManagerEventually(
+	cspcName, cspcNamespace string, tolerations []corev1.Toleration) bool {
+	for i := 0; i < (maxRetry + 100); i++ {
+		tolerationsMatches := true
+		pmList := client.GetPoolManagerList(cspcName, cspcNamespace)
+		for _, pm := range pmList.Items {
+			if !reflect.DeepEqual(pm.Spec.Template.Spec.Tolerations, tolerations) {
+				tolerationsMatches = false
+			}
+		}
+		if tolerationsMatches {
+			return tolerationsMatches
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return false
+}
+
+// HasPriorityClassOnCSPIEventually ...
+func (client *Client) HasPriorityClassOnCSPIEventually(
+	cspcName, cspcNamespace string, priorityClass *string) bool {
+	for i := 0; i < (maxRetry + 100); i++ {
+		priorityClassMatches := true
+		cspiList := client.GetCSPIList(cspcName, cspcNamespace)
+		for _, v := range cspiList.Items {
+			if !reflect.DeepEqual(v.Spec.PoolConfig.PriorityClassName, priorityClass) {
+				priorityClassMatches = false
+			}
+		}
+		if priorityClassMatches {
+			return priorityClassMatches
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return false
+}
+
+// HasPriorityClassOnPoolManagerEventually ...
+func (client *Client) HasPriorityClassOnPoolManagerEventually(
+	cspcName, cspcNamespace string, priorityClass *string) bool {
+	for i := 0; i < (maxRetry + 100); i++ {
+		priorityClassMatches := true
+		pmList := client.GetPoolManagerList(cspcName, cspcNamespace)
+		for _, pm := range pmList.Items {
+			if !reflect.DeepEqual(pm.Spec.Template.Spec.PriorityClassName, *priorityClass) {
+				priorityClassMatches = false
+			}
+		}
+		if priorityClassMatches {
+			return priorityClassMatches
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return false
+}
+
+// HasCompressionOnCSPIEventually ...
+func (client *Client) HasCompressionOnCSPIEventually(
+	cspcName, cspcNamespace string, compression string) bool {
+	for i := 0; i < (maxRetry + 100); i++ {
+		compressionMatches := true
+		cspiList := client.GetCSPIList(cspcName, cspcNamespace)
+		for _, v := range cspiList.Items {
+			if v.Spec.PoolConfig.Compression != compression {
+				compressionMatches = false
+			}
+		}
+		if compressionMatches {
+			return compressionMatches
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return false
+}
+
+// HasROThresholdOnCSPIEventually ...
+func (client *Client) HasROThresholdOnCSPIEventually(
+	cspcName, cspcNamespace string, roThreshold *int) bool {
+	for i := 0; i < (maxRetry + 100); i++ {
+		roThresholdMatches := true
+		cspiList := client.GetCSPIList(cspcName, cspcNamespace)
+		for _, v := range cspiList.Items {
+			if !reflect.DeepEqual(v.Spec.PoolConfig.ROThresholdLimit, roThreshold) {
+				roThresholdMatches = false
+			}
+		}
+		if roThresholdMatches {
+			return roThresholdMatches
+		}
+		time.Sleep(3 * time.Second)
+	}
+	return false
 }


### PR DESCRIPTION
This PR adds tuneable tests that are passed via CSPC mentioned in https://github.com/openebs/cstor-operators/issues/111
Following is the output : 
```bash
Running Suite: CSPC Integration Tests
=====================================
Random Seed: 1596745849
Will run 15 of 15 specs

I0807 02:00:57.972153   11408 cache.go:57] Building CSPC Resource Cache...
CSPC stripe CSPC Pass resource and limit via CSPC 
  creating the cspc,no error should be returned
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:422
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  Expected number of CSPI should be created
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:452

• [SLOW TEST:6.013 seconds]
CSPC
/home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:60
  stripe CSPC
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:420
    Pass resource and limit via CSPC
    /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:421
      Expected number of CSPI should be created
      /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:452
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  Expected number of pool manager deployments should be created
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:459
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  Resource limits should be passed to the CSPI
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:466
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  Resource limits should be passed to the cstor-pool container
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:472
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  Tolerations should be passed to the CSPI
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:478
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  Tolerations should be passed to the pool manager deployments
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:484
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  Priority class should be passed to the CSPI
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:490
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  Priority class should be passed to the pool manager deployments
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:496
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  Compression should be passed to the CSPI
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:502
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC 
  RO threshold should be passed to the CSPI
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:508
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC Deleting the cspc 
  No error should be returned
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:516
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC Deleting the cspc 
  No corresponding cspi(s) should be present
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:528
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC Deleting the cspc 
  No corresponding pool-manger deployments should be present
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:535
•
------------------------------
CSPC stripe CSPC Pass resource and limit via CSPC Deleting the cspc 
  the bdc(s) created by cstor-operator should get deleted
  /home/k8s/go_projects/src/openebs/cstor-operators/tests/cspc/provisioning/provisioning_test.go:542
•
Ran 15 of 15 Specs in 9.203 seconds
SUCCESS! -- 15 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Running Suite: CSPC Integration Tests
=====================================
Random Seed: 1596745849
Will run 0 of 0 specs

I0807 02:01:07.186260   11495 cache.go:57] Building CSPC Resource Cache...

Ran 0 of 0 Specs in 0.091 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 2 suites in 17.599335352s
Test Suite Passed

```

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>