### PR TITLE
feat(tests): add integration tests for scaleup and scaledown of CStorVolume

### DIFF
--- a/tests/cstorvolume/provisioing/provisioning_test.go
+++ b/tests/cstorvolume/provisioing/provisioning_test.go
@@ -491,8 +491,8 @@ func ScaleupAndScaleDownCStorVolume() {
 				VerifyCStorVolumeResourcesStatus(pvcName, testNS, replicaCount)
 
 				// Since scaled up the replicas increasing the count to 1
+				scaleupCStorVolume(2)
 				replicaCount += 2
-				scaleupCStorVolume(replicaCount)
 				verifyScaledCStorVolume(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace)
 
 				// Scaledown to 2 replicas
@@ -514,10 +514,10 @@ func ScaleupAndScaleDownCStorVolume() {
 				verifyScaledCStorVolume(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace)
 
 				//Scaling up when already scaleup is in progress
+				scaleupCStorVolume(1)
 				replicaCount++
-				scaleupCStorVolume(replicaCount)
+				scaleupCStorVolume(1)
 				replicaCount++
-				scaleupCStorVolume(replicaCount)
 				verifyScaledCStorVolume(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace)
 
 				DeProvisionVolume(pvcName, testNS, scName)

--- a/tests/cstorvolume/provisioing/provisioning_utils.go
+++ b/tests/cstorvolume/provisioing/provisioning_utils.go
@@ -155,6 +155,9 @@ func DeProvisionVolume(pvcName, pvcNamespace, scName string) {
 		Expect(err).To(BeNil())
 	}
 
+	err = cstorsuite.client.WaitForPersistentVolumeClaimDeletion(pvcName, pvcNamespace, k8sclient.Poll, k8sclient.ClaimDeletingTimeout)
+	Expect(err).To(BeNil())
+
 	err = cstorsuite.client.KubeClientSet.
 		CoreV1().
 		PersistentVolumeClaims(pvcNamespace).

--- a/tests/cstorvolume/provisioing/provisioning_utils.go
+++ b/tests/cstorvolume/provisioing/provisioning_utils.go
@@ -23,7 +23,7 @@ const (
 )
 
 // ProvisionCSIVolume will provision Volume using CStor-CSI
-func ProvisionCSIVolume(pvcName, pvcNamespace, scName string) {
+func ProvisionCSIVolume(pvcName, pvcNamespace, scName string, replicaCount int) {
 	var (
 		// PVC will contains the PersistentVolumeClaim object created for test
 		pvc *corev1.PersistentVolumeClaim
@@ -34,7 +34,7 @@ func ProvisionCSIVolume(pvcName, pvcNamespace, scName string) {
 	parameters := map[string]string{
 		"cas-type":         "cstor",
 		"cstorPoolCluster": cspc.Name,
-		"replicaCount":     strconv.Itoa(cstorsuite.ReplicaCount),
+		"replicaCount":     strconv.Itoa(replicaCount),
 	}
 	sc = createStorageClass(scName, parameters)
 
@@ -203,7 +203,7 @@ func DeProvisionVolume(pvcName, pvcNamespace, scName string) {
 }
 
 // VerifyCStorVolumeResourcesStatus will verifies the CStorVolume resources health state
-func VerifyCStorVolumeResourcesStatus(pvcName, pvcNamespace string) {
+func VerifyCStorVolumeResourcesStatus(pvcName, pvcNamespace string, replicaCount int) {
 	err := cstorsuite.client.WaitForPersistentVolumeClaimPhase(
 		pvcName, pvcNamespace, corev1.ClaimBound, k8sclient.Poll, k8sclient.ClaimBindingTimeout)
 	Expect(err).To(BeNil())
@@ -228,7 +228,7 @@ func VerifyCStorVolumeResourcesStatus(pvcName, pvcNamespace string) {
 	Expect(err).To(BeNil())
 
 	err = cstorsuite.client.WaitForCVRCountEventually(
-		pvc.Spec.VolumeName, openebsNamespace, cstorsuite.ReplicaCount,
+		pvc.Spec.VolumeName, openebsNamespace, replicaCount,
 		k8sclient.Poll, k8sclient.CVRPhaseTimeout, cstorapis.IsCVRHealthy)
 	Expect(err).To(BeNil())
 
@@ -238,4 +238,44 @@ func VerifyCStorVolumeResourcesStatus(pvcName, pvcNamespace string) {
 	Expect(cvcSpecBuilder).NotTo(BeNil(), "cvcSpecBuilder is not initilized")
 	// SetCVCSpec will hold CVC object inmemory to perform further actions
 	cvcSpecBuilder.SetCVCSpec(cvc)
+}
+
+// scaleupCStorVolume add pool names under the spc of CVC
+func scaleupCStorVolume(poolCount int) {
+	poolNames := cvcSpecBuilder.CVCSpecData.GetUnusedPoolNames()
+	Expect(len(poolNames)).To(BeNumerically(">=", poolCount))
+
+	cvcSpecBuilder = cvcSpecBuilder.ScaleupCVC(poolNames[:poolCount])
+
+	updatedCVC, err := cstorsuite.client.PatchCVCSpec(cvcSpecBuilder.CVC.Name, cvcSpecBuilder.CVC.Namespace, cvcSpecBuilder.CVC.Spec)
+	Expect(err).To(BeNil(), "failed to patch cvc with new pool name details")
+
+	cvcSpecBuilder.SetCVCSpec(updatedCVC)
+}
+
+func verifyScaledCStorVolume(volName, volNamespace string) {
+
+	err := cstorsuite.client.WaitForCStorVolumeReplicaPools(
+	volName, volNamespace, k8sclient.Poll, k8sclient.CVCScaleTimeout)
+	Expect(err).To(BeNil(), "CVC doesn't have desired replica pool names")
+
+	updatedCVC, err := cstorsuite.client.GetCVC(volName, volNamespace)
+	Expect(err).To(BeNil(), "Failed to fetch CVC")
+	cvcSpecBuilder.SetCVCSpec(updatedCVC)
+	
+	// Verify whether newely created CVR's are in Healthy state
+	err = cstorsuite.client.WaitForCVRCountEventually(
+		volName, volNamespace, len(updatedCVC.Spec.Policy.ReplicaPoolInfo),
+		k8sclient.Poll, k8sclient.CVRPhaseTimeout, cstorapis.IsCVRHealthy)
+	Expect(err).To(BeNil())
+	
+	err = cstorsuite.client.VerifyCVRPoolNames(volName, volNamespace, cvcSpecBuilder.CVC.Status.PoolInfo)
+	Expect(err).To(BeNil())
+	
+	replicaIDs, err := cstorsuite.client.GetCVRReplicaIDs(volName, volNamespace)
+	Expect(err).To(BeNil())
+
+	err = cstorsuite.client.WaitForDesiredReplicaConnections(cvcSpecBuilder.CVC.Name,
+		cvcSpecBuilder.CVC.Namespace, replicaIDs, k8sclient.Poll, k8sclient.CVReplicaConnectionTimeout)
+	Expect(err).To(BeNil())
 }

--- a/tests/cstorvolume/provisioing/provisioning_utils.go
+++ b/tests/cstorvolume/provisioing/provisioning_utils.go
@@ -166,7 +166,6 @@ func DeProvisionVolume(pvcName, pvcNamespace, scName string) {
 	err = cstorsuite.client.WaitForPersistentVolumeClaimDeletion(pvcName, pvcNamespace, k8sclient.Poll, k8sclient.ClaimDeletingTimeout)
 	Expect(err).To(BeNil())
 
-
 	err = cstorsuite.client.KubeClientSet.
 		StorageV1().
 		StorageClasses().

--- a/tests/pkg/cstorvolumeconfig/cvcspecbuilder/specbuilder.go
+++ b/tests/pkg/cstorvolumeconfig/cvcspecbuilder/specbuilder.go
@@ -83,6 +83,7 @@ func (cd *CVCSpecData) GetUnusedPoolNames() []string {
 func (c *CVCSpecBuilder) RemovePoolsFromCVCSpec(poolNames []string) {
 	replicaPoolCount := len(c.CVC.Spec.Policy.ReplicaPoolInfo) - len(poolNames)
 	newReplicaPoolsList := make([]cstorapis.ReplicaPoolInfo, replicaPoolCount)
+	index := 0
 	for _, replicaPoolInfo := range c.CVC.Spec.Policy.ReplicaPoolInfo {
 		isRemoved := false
 		for _, poolName := range poolNames {
@@ -93,7 +94,8 @@ func (c *CVCSpecBuilder) RemovePoolsFromCVCSpec(poolNames []string) {
 			}
 		}
 		if !isRemoved {
-			newReplicaPoolsList = append(newReplicaPoolsList, replicaPoolInfo)
+			newReplicaPoolsList[index] = replicaPoolInfo
+			index++
 		}
 	}
 	c.CVC.Spec.Policy.ReplicaPoolInfo = newReplicaPoolsList

--- a/tests/pkg/cstorvolumeconfig/cvcspecbuilder/specbuilder.go
+++ b/tests/pkg/cstorvolumeconfig/cvcspecbuilder/specbuilder.go
@@ -78,6 +78,27 @@ func (cd *CVCSpecData) GetUnusedPoolNames() []string {
 	return unUsedPoolNames
 }
 
+// RemovePoolsFromCVCSpec removes the pool names from spec and add
+// them to used set
+func (c *CVCSpecBuilder) RemovePoolsFromCVCSpec(poolNames []string) {
+	replicaPoolCount := len(c.CVC.Spec.Policy.ReplicaPoolInfo) - len(poolNames)
+	newReplicaPoolsList := make([]cstorapis.ReplicaPoolInfo, replicaPoolCount)
+	for _, replicaPoolInfo := range c.CVC.Spec.Policy.ReplicaPoolInfo {
+		isRemoved := false
+		for _, poolName := range poolNames {
+			if replicaPoolInfo.PoolName == poolName {
+				c.CVCSpecData.AddPoolToUnusedSet(poolName)
+				isRemoved = true
+				break
+			}
+		}
+		if !isRemoved {
+			newReplicaPoolsList = append(newReplicaPoolsList, replicaPoolInfo)
+		}
+	}
+	c.CVC.Spec.Policy.ReplicaPoolInfo = newReplicaPoolsList
+}
+
 // SetCVCSpec sets the CVC spec in spec builder
 // Usually this function will be called after verifying the
 // CStorVolume resource successfull creation
@@ -123,6 +144,10 @@ func (c *CVCSpecBuilder) ScaleupCVC(poolNames []string) *CVCSpecBuilder {
 	}
 
 	for _, poolName := range poolNames {
+		if !c.CVCSpecData.UnUsedPools[poolName] {
+			klog.Warningf("%s Pool is not present in unused list of %s volume", poolName, c.CVC.Name)
+			continue
+		}
 		if c.CVCSpecData.UnUsedPools[poolName] {
 			c.CVCSpecData.AddPoolToUsedSet(poolName)
 			c.CVC.Spec.Policy.ReplicaPoolInfo = append(

--- a/tests/pkg/k8sclient/cspc_util.go
+++ b/tests/pkg/k8sclient/cspc_util.go
@@ -114,8 +114,8 @@ func (client *Client) GetCStorPoolInstanceNames(cspcName, cspcNamespace string) 
 		return []string{}, errors.Wrapf(err, "failed to list pool instances belongs to %s", cspcName)
 	}
 	poolNames := make([]string, len(cspiList.Items))
-	for _, cspiObj := range cspiList.Items {
-		poolNames = append(poolNames, cspiObj.Name)
+	for i, cspiObj := range cspiList.Items {
+		poolNames[i] = cspiObj.Name
 	}
 	return poolNames, nil
 }

--- a/tests/pkg/k8sclient/cv_util.go
+++ b/tests/pkg/k8sclient/cv_util.go
@@ -75,7 +75,9 @@ func (client *Client) WaitForDesiredReplicaConnections(
 			return err
 		}
 		if len(desiredReplicaIDs) != len(cvObj.Status.ReplicaDetails.KnownReplicas) {
-			klog.Infof("Waiting for replica ids to available on CStorVolume %s", cvObj.Name)
+			klog.Infof("Waiting for %d replicas to available on CStorVolume %s but got %d",
+				len(desiredReplicaIDs), cvObj.Name,
+				len(cvObj.Status.ReplicaDetails.KnownReplicas))
 			continue
 		}
 		currentReplicaIds := []string{}
@@ -93,6 +95,7 @@ func (client *Client) WaitForDesiredReplicaConnections(
 			return errors.Errorf("CStorVolume CF %d is not matching with expected CF %d",
 				consistencyFactor, cvObj.Spec.ConsistencyFactor)
 		}
+		return nil
 	}
 	return errors.Errorf("CStorVolume %s doesn't have desired replica IDs timeout occured", cvName)
 }

--- a/tests/pkg/k8sclient/cvc_util.go
+++ b/tests/pkg/k8sclient/cvc_util.go
@@ -35,6 +35,8 @@ var (
 	CVCPhaseTimeout = 3 * time.Minute
 	// CVCDeletingTimeout is How long claims have to become deleted.
 	CVCDeletingTimeout = 3 * time.Minute
+	// CVCScaleTimeout is how long CVC requires to change the replica pools list
+	CVCScaleTimeout = 3 * time.Minute
 )
 
 // WaitForCStorVolumeConfigPhase waits for a CStorVolumeConfig to
@@ -66,11 +68,11 @@ func (client *Client) WaitForCStorVolumeReplicaPools(
 			return err
 		}
 		desiredPoolNames := cvcObj.GetDesiredReplicaPoolNames()
-		if util.IsChangeInLists(desiredPoolNames, cvcObj.Status.PoolInfo) {
+		if !util.IsChangeInLists(desiredPoolNames, cvcObj.Status.PoolInfo) {
 			return nil
 		}
 		klog.Infof(
-			"CStorVolumeConfig %s found and desired pools=%v current pools=%v (%v)",
+			"Waiting for CStorVolumeConfig %s to match desired pools=%v and current pools=%v (%v)",
 			cvcName, desiredPoolNames, cvcObj.Status.PoolInfo, time.Since(start))
 	}
 	return errors.Errorf("CStorVolumeConfig %s replicas are not yet present in desired pools", cvcName)

--- a/tests/pkg/k8sclient/cvr_util.go
+++ b/tests/pkg/k8sclient/cvr_util.go
@@ -53,13 +53,25 @@ func (client *Client) WaitForCVRCountEventually(
 func (client *Client) VerifyCVRPoolNames(name, namespace string, poolNames []string) error {
 	cvrList, err := client.GetCVRList(name, namespace)
 	if err != nil {
-		// Currently we are returning error but based on the requirment we can retry to get PVC
 		return err
 	}
 	if util.IsChangeInLists(poolNames, cvrList.GetPoolNames()) {
 		return errors.Errorf("One/more CStorVolumeReplicas are not in pool names %v", poolNames)
 	}
 	return nil
+}
+
+// GetCVRReplicaIDs return list of replicaIDs of replicas of provided Volume
+func (client *Client) GetCVRReplicaIDs(name, namespace string) ([]string, error) {
+	cvrList, err := client.GetCVRList(name, namespace)
+	if err != nil {
+		return nil, err
+	}
+	replicaIDs := make([]string, len(cvrList.Items))
+	for _, cvrObj := range cvrList.Items {
+		replicaIDs = append(replicaIDs, cvrObj.Spec.ReplicaID)
+	}
+	return replicaIDs, nil
 }
 
 // GetCVRList will fetch the CVRList from etcd

--- a/tests/pkg/k8sclient/cvr_util.go
+++ b/tests/pkg/k8sclient/cvr_util.go
@@ -24,6 +24,7 @@ import (
 	"github.com/openebs/api/pkg/util"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
 )
 
 var (
@@ -45,6 +46,7 @@ func (client *Client) WaitForCVRCountEventually(
 		if len(filteredList.Items) == expectedCount {
 			return nil
 		}
+		klog.Infof("Waiting for %d CStorVolumeReplias to exist in expected state but got %d", expectedCount, len(filteredList.Items))
 	}
 	return errors.Errorf("Expected count %d of CStorVolumeReplicas are not availbe for volume %s", expectedCount, name)
 }
@@ -68,8 +70,8 @@ func (client *Client) GetCVRReplicaIDs(name, namespace string) ([]string, error)
 		return nil, err
 	}
 	replicaIDs := make([]string, len(cvrList.Items))
-	for _, cvrObj := range cvrList.Items {
-		replicaIDs = append(replicaIDs, cvrObj.Spec.ReplicaID)
+	for i, cvrObj := range cvrList.Items {
+		replicaIDs[i] = cvrObj.Spec.ReplicaID
 	}
 	return replicaIDs, nil
 }

--- a/tests/pkg/k8sclient/pvc_util.go
+++ b/tests/pkg/k8sclient/pvc_util.go
@@ -83,6 +83,7 @@ func (client *Client) WaitForPersistentVolumeClaimDeletion(pvcName, pvcNamespace
 			}
 			return err
 		}
+		klog.Infof("Waiting for %s pvc in %s namespace to be deleted since(%v)", pvcName, pvcNamespace, time.Since(start))
 	}
 	return errors.Errorf("PersistentVolumeClaim %s is not removed from the system within %v", pvcName, timeout)
 }


### PR DESCRIPTION
This PR adds CStorVolume scaleup and scaledown integration tests.
It covers the following scenario
- Scaling up cStor volume.
-  Scaling down cStor volume.
-  Scaling up cStor volume when not enough pool are available. (-ve)
-  Scaleup in the same pool. (-ve)
-  Scaleup when already a scaleup operation is in progress.(-ve)
-  Scale down when already a scale down operation is in progress.(-ve)

**NOTE**: This PR needs to be merged after merging https://github.com/openebs/cstor-operators/pull/148