### PR TITLE
chore(version): update upgrade matrix with valid current versions

### DIFF
--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -6,7 +6,8 @@ import (
 
 var (
 	validCurrentVersions = map[string]bool{
-		"1.9.0": true, "1.10.0": true, "1.11.0": true,
+		"1.10.0": true, "1.11.0": true, "1.12.0": true,
+		"2.0.0": true,
 	}
 	validDesiredVersion = strings.Split(GetVersion(), "-")[0]
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR adds `1.12.0` & `2.0.0` as valid current versions to upgrade matrix for upgrade support from `1.12.0` and RC upgrades in `2.0.0`.

This PR fixes the issue: https://github.com/openebs/openebs/issues/3098