### PR TITLE
refact(vendor): sync with openebs apis changes

### DIFF
--- a/deploy/crds/all_cstor_crds.yaml
+++ b/deploy/crds/all_cstor_crds.yaml
@@ -509,6 +509,7 @@ spec:
     description: The amount of storage space within the pool that has been physically
       allocated
     name: Allocated
+    priority: 1
     type: string
   - JSONPath: .status.capacity.free
     description: The amount of usable free space available in the pool
@@ -533,6 +534,7 @@ spec:
   - JSONPath: .spec.poolConfig.dataRaidGroupType
     description: Represents the type of the storage pool
     name: Type
+    priority: 1
     type: string
   - JSONPath: .status.phase
     description: Identifies the current health of the pool
@@ -884,6 +886,10 @@ spec:
             readOnly:
               description: ReadOnly if pool is readOnly or not
               type: boolean
+          required:
+          - healthyReplicas
+          - provisionedReplicas
+          - readOnly
           type: object
         versionDetails:
           description: VersionDetails is the openebs version.

--- a/deploy/csi-operator.yaml
+++ b/deploy/csi-operator.yaml
@@ -500,6 +500,8 @@ spec:
   # Supports persistent inline volumes.
   volumeLifecycleModes:
   - Persistent
+  # Not yet supported but added just to support upgrade control plane seamlessly
+  - Ephemeral
   # To determine at runtime which mode a volume uses, pod info and its
   # "csi.storage.k8s.io/ephemeral" entry are needed.
   podInfoOnMount: true

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c
+	github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -389,6 +389,8 @@ github.com/openebs/api v1.12.1-0.20200729172328-4b0764aeaaf6 h1:3r1ByPvaWBJpLhGs
 github.com/openebs/api v1.12.1-0.20200729172328-4b0764aeaaf6/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c h1:fZmO/A7BnxFAg9y1gjhtN6IG1ZBj0e0bLJTQtOI1Tk4=
 github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
+github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932 h1:YzV1nspFTKrCa7c2XeWPcrU9KRvV9Ul9Yu9SLHqldas=
+github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/vendor/github.com/openebs/api/pkg/apis/cstor/v1/cstorpoolinstance.go
+++ b/vendor/github.com/openebs/api/pkg/apis/cstor/v1/cstorpoolinstance.go
@@ -31,13 +31,13 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=cspi
 // +kubebuilder:printcolumn:name="HostName",type=string,JSONPath=`.spec.hostName`,description="Host name where cstorpool instances scheduled"
-// +kubebuilder:printcolumn:name="Allocated",type=string,JSONPath=`.status.capacity.used`,description="The amount of storage space within the pool that has been physically allocated"
+// +kubebuilder:printcolumn:name="Allocated",type=string,JSONPath=`.status.capacity.used`,description="The amount of storage space within the pool that has been physically allocated",priority=1
 // +kubebuilder:printcolumn:name="Free",type=string,JSONPath=`.status.capacity.free`,description="The amount of usable free space available in the pool"
 // +kubebuilder:printcolumn:name="Capacity",type=string,JSONPath=`.status.capacity.total`,description="Total amount of usable space in pool"
 // +kubebuilder:printcolumn:name="ReadOnly",type=boolean,JSONPath=`.status.readOnly`,description="Identifies the pool read only mode"
 // +kubebuilder:printcolumn:name="ProvisionedReplicas",type=integer,JSONPath=`.status.provisionedReplicas`,description="Represents no.of replicas present in the pool"
 // +kubebuilder:printcolumn:name="HealthyReplicas",type=integer,JSONPath=`.status.healthyReplicas`,description="Represents no.of healthy replicas present in the pool"
-// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.poolConfig.dataRaidGroupType`,description="Represents the type of the storage pool"
+// +kubebuilder:printcolumn:name="Type",type=string,JSONPath=`.spec.poolConfig.dataRaidGroupType`,description="Represents the type of the storage pool",priority=1
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.phase`,description="Identifies the current health of the pool"
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="Age of CStorPoolInstance"
 type CStorPoolInstance struct {
@@ -117,13 +117,13 @@ type CStorPoolInstanceStatus struct {
 	// Capacity describes the capacity details of a cstor pool
 	Capacity CStorPoolInstanceCapacity `json:"capacity,omitempty"`
 	//ReadOnly if pool is readOnly or not
-	ReadOnly bool `json:"readOnly,omitempty"`
+	ReadOnly bool `json:"readOnly"`
 	// ProvisionedReplicas describes the total count of Volume Replicas
 	// present in the cstor pool
-	ProvisionedReplicas int32 `json:"provisionedReplicas,omitempty"`
+	ProvisionedReplicas int32 `json:"provisionedReplicas"`
 	// HealthyReplicas describes the total count of healthy Volume Replicas
 	// in the cstor pool
-	HealthyReplicas int32 `json:"healthyReplicas,omitempty"`
+	HealthyReplicas int32 `json:"healthyReplicas"`
 }
 
 // CStorPoolInstanceCapacity stores the pool capacity related attributes.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c
+# github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932
 github.com/openebs/api/pkg/apis/cstor
 github.com/openebs/api/pkg/apis/cstor/v1
 github.com/openebs/api/pkg/apis/openebs.io


### PR DESCRIPTION
This PR does the following changes
- Updates the vendor files to point to the latest API changes
- Updates the CSPI CRD changes to intact with PR https://github.com/openebs/api/pull/63.
- Update the CSIDriver with Ephemeral `volumeLifecycleModes` (Just not to break the upgrade workflow)

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>