### PR TITLE
fix(roThreshold): update default roThresholdLimit to 85% during sync time

### DIFF
--- a/pkg/controllers/cspc-controller/sync.go
+++ b/pkg/controllers/cspc-controller/sync.go
@@ -466,6 +466,7 @@ https://github.com/openebs/api/tree/master/design/cstor/v1
 ToDo: Offload this defaulting mechanism to mutating webhook server.
 */
 func defaultPoolConfig(cspi *cstor.CStorPoolInstance, cspc *cstor.CStorPoolCluster) {
+	defaultROThresholdLimit := 85
 	if cspi.Spec.PoolConfig.Resources == nil {
 		cspi.Spec.PoolConfig.Resources = cspc.Spec.DefaultResources
 	}
@@ -479,6 +480,10 @@ func defaultPoolConfig(cspi *cstor.CStorPoolInstance, cspc *cstor.CStorPoolClust
 	if cspi.Spec.PoolConfig.PriorityClassName == nil {
 		priorityClassName := cspc.Spec.DefaultPriorityClassName
 		cspi.Spec.PoolConfig.PriorityClassName = &priorityClassName
+	}
+
+	if cspi.Spec.PoolConfig.ROThresholdLimit == nil {
+		cspi.Spec.PoolConfig.ROThresholdLimit = &defaultROThresholdLimit
 	}
 }
 

--- a/pkg/controllers/cspc-controller/sync.go
+++ b/pkg/controllers/cspc-controller/sync.go
@@ -47,6 +47,9 @@ type upgradeFunc func(u *upgradeParams) (*cstor.CStorPoolCluster, error)
 
 var (
 	upgradeMap = map[string]upgradeFunc{}
+	// defaultROThresholdLimit is the default
+	// value in form of percentage for ROThreshold limit
+	defaultROThresholdLimit = 85
 )
 
 func (c *Controller) sync(cspc *cstor.CStorPoolCluster, cspiList *cstor.CStorPoolInstanceList) error {
@@ -466,7 +469,6 @@ https://github.com/openebs/api/tree/master/design/cstor/v1
 ToDo: Offload this defaulting mechanism to mutating webhook server.
 */
 func defaultPoolConfig(cspi *cstor.CStorPoolInstance, cspc *cstor.CStorPoolCluster) {
-	defaultROThresholdLimit := 85
 	if cspi.Spec.PoolConfig.Resources == nil {
 		cspi.Spec.PoolConfig.Resources = cspc.Spec.DefaultResources
 	}


### PR DESCRIPTION
This PR updates the cStorPoolInstance with the default
value of the ROThresholdLimit if user doesn't specify
ROThresholdLimit. The default value of ROThresholdLimit
is 85%. 

**NOTE**:
- This PR is to just display roThresholdLimit on CSPI resources(
   It is already handled internally in CSPI controller).

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>