### PR TITLE
feat(ci): auto-assign github PR reviewers and assignee using github-action

### DIFF
--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -1,16 +1,17 @@
 addReviewers: true
 
-addAssignees: author
+addAssignees: false
 
 # Set this to the length of the reviewers list
 # because the default was not including everyone
-numberOfReviewers: 3
+numberOfReviewers: 2
 
 reviewers:
   - prateekpandey14
-  - sonasingh46
-  - mittachaitu
   - shubham14bajpai
+  - mittachaitu
+  - sonasingh46
+  - kmova
 
 skipKeywords:
   - wip

--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -1,0 +1,16 @@
+addReviewers: true
+
+addAssignees: author
+
+# Set this to the length of the reviewers list
+# because the default was not including everyone
+numberOfReviewers: 3
+
+reviewers:
+  - prateekpandey14
+  - sonasingh46
+  - mittachaitu
+  - shubham14bajpai
+
+skipKeywords:
+  - wip

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -4,7 +4,7 @@ name: 'Auto Assign PRs'
 # This should mean PRs from forks are supported.
 on: 
   pull_request_target:
-    types: [opened, reopened, sychronized]
+    types: [opened, reopened, sychronize, ready_for_review]
 
 jobs:
   add-reviewers:
@@ -13,3 +13,4 @@ jobs:
       - uses: kentaro-m/auto-assign-action@v1.1.1
         with: 
           configuration-path: ".github/auto_assign.yml"
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -1,0 +1,15 @@
+name: 'Auto Assign PRs'
+
+# pull_request_target means that this will run on pull requests, but in the context of the base repo.
+# This should mean PRs from forks are supported.
+on: 
+  pull_request_target:
+    types: [opened, reopened, sychronized]
+
+jobs:
+  add-reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.1.1
+        with: 
+          configuration-path: ".github/auto_assign.yml"


### PR DESCRIPTION
Use a GitHub Action to automatically assign GitHub PRs to the author, as
well as add reviewers.

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>