### PR TITLE
feat(CSPC, nodeName changes): add suport to move the CStorPoolInstances to specified node

### DIFF
--- a/pkg/controllers/cspc-controller/sync.go
+++ b/pkg/controllers/cspc-controller/sync.go
@@ -447,8 +447,8 @@ func (pc *PoolConfig) syncCSPIWithCSPC(cspc *cstor.CStorPoolCluster, cspi *cstor
 	// one blockdevice name in CSPI data raid groups is matched to
 	// blockdevice name in data raidgroups in CSPC spec then
 
-	//NOTE: CSPC pools spec consist repeation of blockdevice names
-	// is outof context. This kind of CSPC should not reconcile
+	//NOTE: CSPC pools spec consist repetion of blockdevice names
+	// is outof context. This kind of CSPC should not be reconciled
 	for _, poolSpec := range cspc.Spec.Pools {
 
 		if reflect.DeepEqual(poolSpec.NodeSelector, cspi.Spec.NodeSelector) ||

--- a/pkg/controllers/cspc-controller/sync.go
+++ b/pkg/controllers/cspc-controller/sync.go
@@ -438,11 +438,31 @@ func (pc *PoolConfig) syncCSPI(cspc *cstor.CStorPoolCluster) error {
 func (pc *PoolConfig) syncCSPIWithCSPC(cspc *cstor.CStorPoolCluster, cspi *cstor.CStorPoolInstance) error {
 	cspiCopy := cspi.DeepCopy()
 	klog.V(2).Infof("Syncing cspi %s from parent cspc %s", cspiCopy.Name, cspc.Name)
+
+	// Finding out the cspc pool spec in the following way:
+	// 1. Using node selectors i.e if node selector of cspc and cspi is
+	// matched then that is the spec of CSPC belongs to searching CSPI
+	//			(If above step failed then find using step2)
+	// 2. Find out using data raidgroup blockdevice names i.e if atleast
+	// one blockdevice name in CSPI data raid groups is matched to
+	// blockdevice name in data raidgroups in CSPC spec then
+
+	//NOTE: CSPC pools spec consist repeation of blockdevice names
+	// is outof context. This kind of CSPC should not reconcile
 	for _, poolSpec := range cspc.Spec.Pools {
-		if reflect.DeepEqual(poolSpec.NodeSelector, cspi.Spec.NodeSelector) {
+
+		if reflect.DeepEqual(poolSpec.NodeSelector, cspi.Spec.NodeSelector) ||
+			pc.isCSPISpecExist([]cstor.PoolSpec{poolSpec}, cspi.Spec) {
+
 			poolSpec := poolSpec
-			cspiCopy.Spec.PoolConfig = poolSpec.PoolConfig
+			cspiCopy = cspiCopy.WithPoolConfig(poolSpec.PoolConfig).
+				WithNodeSelectorByReference(poolSpec.NodeSelector)
 			defaultPoolConfig(cspiCopy, cspc)
+			hostName, err := pc.AlgorithmConfig.GetNodeFromLabelSelector(cspiCopy.Spec.NodeSelector)
+			if err != nil || hostName == "" {
+				return errors.Errorf("could not use node for selectors {%v}: {%s}", cspiCopy.Spec.NodeSelector, err.Error())
+			}
+			cspiCopy.Spec.HostName = hostName
 			break
 		}
 	}

--- a/pkg/cspc/algorithm/select_node.go
+++ b/pkg/cspc/algorithm/select_node.go
@@ -107,7 +107,7 @@ func getLabelSelectorString(selector map[string]string) string {
 // GetUsedNode returns a map of node for which pool has already been created.
 func (ac *Config) GetUsedNodes() (map[string]bool, error) {
 	usedNode := make(map[string]bool)
-	cspList, err := ac.
+	cspiList, err := ac.
 		clientset.
 		CstorV1().
 		CStorPoolInstances(ac.Namespace).
@@ -116,7 +116,7 @@ func (ac *Config) GetUsedNodes() (map[string]bool, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not list already created cspi(s)")
 	}
-	for _, cspObj := range cspList.Items {
+	for _, cspObj := range cspiList.Items {
 		usedNode[cspObj.Labels[string(types.HostNameLabelKey)]] = true
 	}
 	return usedNode, nil
@@ -126,7 +126,7 @@ func (ac *Config) GetUsedNodes() (map[string]bool, error) {
 // present on provisioned CSPI
 func (ac *Config) GetUsedBlockDevices() (map[string]bool, error) {
 	usedBlockDevices := make(map[string]bool)
-	cspList, err := ac.
+	cspiList, err := ac.
 		clientset.
 		CstorV1().
 		CStorPoolInstances(ac.Namespace).
@@ -135,7 +135,7 @@ func (ac *Config) GetUsedBlockDevices() (map[string]bool, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "could not list already provisioned cspi(s)")
 	}
-	for _, cspiObj := range cspList.Items {
+	for _, cspiObj := range cspiList.Items {
 		for _, rg := range append(cspiObj.Spec.DataRaidGroups, cspiObj.Spec.WriteCacheRaidGroups...) {
 			for _, cspiBD := range rg.CStorPoolInstanceBlockDevices {
 				usedBlockDevices[cspiBD.BlockDeviceName] = true


### PR DESCRIPTION
This PR adds support to move CStorPoolInstances to
different node when nodeSelector has been updated
with new node details.

Fixes https://github.com/openebs/openebs/issues/2396

**Changes Made**:
- Currently CSPC pool specs and CStorPoolInstance are
mapping using nodeSelectors but to support few scenarios
we should identify by making use of blockdevices in data raid
groups.


**Use Case**: This use case is to support following scenarios:
1. When node name changes upon reboots of node updating corresponding
   node selector on CSPC will move the CStorPools to new node.
2. When existing node is replaced with new node in the cluster updating
  corresponding node selector on CSPC should move the CStorPools to new node.
3. Scaling down the nodes in cluster to 0 and scaling back should work by
   updating node selectors on CSPC.

## How users can make use:
### Existing Setup
- kubectl get nodes
```sh
NAME                                           STATUS   ROLES    AGE   VERSION
ip-192-168-29-151.us-east-2.compute.internal   Ready    <none>   16m   v1.15.9
ip-192-168-36-89.us-east-2.compute.internal    Ready    <none>   8h    v1.15.9
ip-192-168-74-129.us-east-2.compute.internal   Ready    <none>   8h    v1.15.9
```
- kubectl get bd -n openebs
```sh
 kubectl get bd -n openebs
NAME                                           NODENAME                                       SIZE          CLAIMSTATE   STATUS   AGE
blockdevice-7d311a98255a454a717427b5c2d38426   ip-192-168-36-89.us-east-2.compute.internal    10737418240   Claimed      Active   164m
blockdevice-c2c846cce1befec7fbdcbae254329b0b   ip-192-168-74-129.us-east-2.compute.internal   10737418240   Claimed      Active   164m
blockdevice-c608881cd3edbeab674a1aee7e0a1fc3   ip-192-168-29-151.us-east-2.compute.internal   10737418240   Claimed      Active   164m
```
- Applied CSPC yaml
```yaml
apiVersion: cstor.openebs.io/v1
kind: CStorPoolCluster
metadata:
  name: cstor-disk-cspc
  namespace: openebs
  annotations:
    #reconcile.openebs.io/disable-dependants: "true"
spec:
  pools:
    - nodeSelector:
        kubernetes.io/hostname: "ip-192-168-74-129"
      dataRaidGroups:
      - blockDevices:
          - blockDeviceName: "blockdevice-c2c846cce1befec7fbdcbae254329b0b"
      poolConfig:
        dataRaidGroupType: "stripe"
    - nodeSelector:
        kubernetes.io/hostname: "ip-192-168-36-89"
      dataRaidGroups:
      - blockDevices:
          - blockDeviceName: "blockdevice-7d311a98255a454a717427b5c2d38426"
      poolConfig:
        dataRaidGroupType: "stripe"
    - nodeSelector:
        kubernetes.io/hostname: "ip-192-168-29-151"
      dataRaidGroups:
      - blockDevices:
          - blockDeviceName: "blockdevice-c608881cd3edbeab674a1aee7e0a1fc3"
      poolConfig:
        dataRaidGroupType: "stripe"
```
### Cluster has been scaled down and scaled up
- Nodes name has been updated `kubectl get bd -n openebs` but attached same old disks to new node 
```sh
kubectl get nodes
NAME                                           STATUS   ROLES    AGE     VERSION
ip-192-168-14-90.us-east-2.compute.internal    Ready    <none>   118s    v1.15.9
ip-192-168-49-43.us-east-2.compute.internal    Ready    <none>   5m55s   v1.15.9
ip-192-168-94-113.us-east-2.compute.internal   Ready    <none>   4m6s    v1.15.9
```
- Old disks have been attached to new nodes
```sh
kubectl get bd -n openebs 
NAME                                           NODENAME                                       SIZE          CLAIMSTATE   STATUS   AGE
blockdevice-7d311a98255a454a717427b5c2d38426   ip-192-168-49-43.us-east-2.compute.internal    10737418240   Claimed      Active   176m
blockdevice-c2c846cce1befec7fbdcbae254329b0b   ip-192-168-94-113.us-east-2.compute.internal   10737418240   Claimed      Active   176m
blockdevice-c608881cd3edbeab674a1aee7e0a1fc3   ip-192-168-14-90.us-east-2.compute.internal    10737418240   Claimed      Active   176m
```
- Updated CSPC with the new node name changes
```yaml
apiVersion: cstor.openebs.io/v1
kind: CStorPoolCluster
metadata:
  name: cstor-disk-cspc
  namespace: openebs
  annotations:
    #reconcile.openebs.io/disable-dependants: "true"
spec:
  pools:
    - nodeSelector:
        kubernetes.io/hostname: "ip-192-168-94-113"
      dataRaidGroups:
      - blockDevices:
          - blockDeviceName: "blockdevice-c2c846cce1befec7fbdcbae254329b0b"
      poolConfig:
        dataRaidGroupType: "stripe"
    - nodeSelector:
        kubernetes.io/hostname: "ip-192-168-49-43"
      dataRaidGroups:
      - blockDevices:
          - blockDeviceName: "blockdevice-7d311a98255a454a717427b5c2d38426"
      poolConfig:
        dataRaidGroupType: "stripe"
    - nodeSelector:
        kubernetes.io/hostname: "ip-192-168-14-90"
      dataRaidGroups:
      - blockDevices:
          - blockDeviceName: "blockdevice-c608881cd3edbeab674a1aee7e0a1fc3"
      poolConfig:
        dataRaidGroupType: "stripe"
```
**Note to Users**:
- Updating labels should be performed only after migrating the underlying disks to a new node.


**NOTE**:
- For more details visit [OEP](https://github.com/openebs/openebs/pull/3113).
- Along with CSPI migration from one node to different node corresponding volume
  replicas in the pool(CSPI) will also be migrated(CVRs has a stickiness to CSPI so
  CVRs will be automatically moved with CSPI to new node).

**TODO**:
- Update the documentation.


Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>