### PR TITLE
fix(backup): fixing deletion of backup snapshot

### DIFF
--- a/pkg/server/cstorvolumeconfig/backup_endpoint.go
+++ b/pkg/server/cstorvolumeconfig/backup_endpoint.go
@@ -287,7 +287,7 @@ func (bOps *backupAPIOps) deleteBackup(backup, volname, ns, schedule string) err
 	snapshot := snapshot.Snapshot{
 		VolumeName:   volname,
 		SnapshotName: backup,
-		Namespace:    ns,
+		Namespace:    bOps.namespace,
 		SnapClient:   bOps.snapshotter,
 	}
 	// Snapshot Name and backup name are same


### PR DESCRIPTION
Changes:
- This PR fixes snapshot deletion during backup delete request.
  Existing backup endpoint uses cstor-backup resource's namespace to fetch relevant cstorvolume resource for PV, to delete the snapshot. This will result into error since cstorvolume resource are created in operator namespace instead of application namespace.

Signed-off-by: mayank <mayank.patel@mayadata.io>