### PR TITLE
Bump golang version to 1.14.7

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.6
+        go-version: 1.14.7
       id: go
 
     - name: Check out code into the Go module directory
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.6
+        go-version: 1.14.7
       id: go
 
     - name: Check out code into the Go module directory

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ dist: bionic
 language: go
 
 go:
-  - 1.13.x
+  - 1.14.7
 
 env:
   global:


### PR DESCRIPTION
This commit is to change golang version from 1.13.6 to 1.14.7

Signed-off-by: ajeetrai707 <ajeetrai707@gmail.com>