### PR TITLE
feat(cspc): add capability to specify allowed BD tags on CSPC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932
+	github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,8 @@ github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c h1:fZmO/A7BnxFAg9y1
 github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932 h1:YzV1nspFTKrCa7c2XeWPcrU9KRvV9Ul9Yu9SLHqldas=
 github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
+github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f h1:ebsHrWNo+Ypp5C9eKMC8lX9z9OrZxCUkWAzN2otwfek=
+github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/controllers/cspc-controller/util/cspc_util_test.go
+++ b/pkg/controllers/cspc-controller/util/cspc_util_test.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/controllers/cstorvolumeconfig/volume_operations_test.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations_test.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/cspc/algorithm/select_node.go
+++ b/pkg/cspc/algorithm/select_node.go
@@ -32,9 +32,6 @@ import (
 
 const (
 	unit = 1024
-	// CStorBDTagAnnotationKey is the annotation key for CSPC allowed BD tags
-	// ToDo: Move to API type (openebs/api)
-	OpenEBSAllowedBDTagKey = "openebs.io/allowed-bd-tags"
 )
 
 // SelectNode returns a node where pool should be created.
@@ -168,7 +165,7 @@ func (ac *Config) ClaimBD(bdObj openebsio.BlockDevice) error {
 
 	// If the BD has a BD tag present then we need to decide whether
 	// cStor can use it or not.
-	// If there is not BD tag present on BD then still the BD is safe to use.
+	// If there is no BD tag present on BD then still the BD is safe to use.
 	value, ok := bdObj.Labels[types.BlockDeviceTagLabelKey]
 	var allowedBDTags map[string]bool
 	if ok {
@@ -185,7 +182,7 @@ func (ac *Config) ClaimBD(bdObj openebsio.BlockDevice) error {
 		if !allowedBDTags[strings.TrimSpace(value)] {
 			return errors.Errorf("cannot use bd {%s} as it has tag %s but "+
 				"cspc has allowed bd tags as %s",
-				bdObj.Name, value, ac.CSPC.GetAnnotations()[OpenEBSAllowedBDTagKey])
+				bdObj.Name, value, ac.CSPC.GetAnnotations()[types.OpenEBSAllowedBDTagKey])
 		}
 	}
 
@@ -228,7 +225,7 @@ func (ac *Config) ClaimBD(bdObj openebsio.BlockDevice) error {
 // Then, a map {"fast":true,"slow":true} is returned.
 func getAllowedTagMap(cspcAnnotation map[string]string) map[string]bool {
 	allowedTagsMap := make(map[string]bool)
-	allowedTags := cspcAnnotation[OpenEBSAllowedBDTagKey]
+	allowedTags := cspcAnnotation[types.OpenEBSAllowedBDTagKey]
 	if strings.TrimSpace(allowedTags) == "" {
 		return allowedTagsMap
 	}

--- a/pkg/cspc/algorithm/select_node.go
+++ b/pkg/cspc/algorithm/select_node.go
@@ -18,6 +18,7 @@ package algorithm
 
 import (
 	"fmt"
+	"strings"
 
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	openebsio "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
@@ -31,6 +32,9 @@ import (
 
 const (
 	unit = 1024
+	// CStorBDTagAnnotationKey is the annotation key for CSPC allowed BD tags
+	// ToDo: Move to API type (openebs/api)
+	CStorBDTagAnnotationKey = "cstor.openebs.io/allowed-bd-tags"
 )
 
 // SelectNode returns a node where pool should be created.
@@ -162,6 +166,29 @@ func (ac *Config) ClaimBD(bdObj openebsio.BlockDevice) error {
 		return errors.Errorf("failed to get capacity from block device %s:%s", bdObj.Name, err)
 	}
 
+	// If the BD has a BD tag present then we need to decide whether
+	// cStor can use it or not.
+	// If there is not BD tag present on BD then still the BD is safe to use.
+	value, ok := bdObj.Labels[types.BlockDeviceTagLabelKey]
+	var allowedBDTags map[string]bool
+	if ok {
+		// If the BD tag value is empty -- cStor cannot use it.
+		if strings.TrimSpace(value) == "" {
+			return errors.Errorf("failed to create block device "+
+				"claim for bd {%s} as it has empty value for bd tag", bdObj.Name)
+		}
+
+		// If the BD tag in the BD is present in allowed annotations on CSPC then
+		// it means that this BD can be considered in provisioning else it should not
+		// be considered
+		allowedBDTags = getAllowedTagMap(ac.CSPC.GetAnnotations())
+		if !allowedBDTags[strings.TrimSpace(value)] {
+			return errors.Errorf("cannot use bd {%s} as it has tag %s but "+
+				"cspc has allowed bd tags as %s",
+				bdObj.Name, value, ac.CSPC.GetAnnotations()[CStorBDTagAnnotationKey])
+		}
+	}
+
 	newBDCObj := openebsio.NewBlockDeviceClaim().
 		WithName("bdc-cstor-" + string(bdObj.UID)).
 		WithNamespace(ac.Namespace).
@@ -172,6 +199,15 @@ func (ac *Config) ClaimBD(bdObj openebsio.BlockDevice) error {
 		WithCapacity(resourceList).
 		WithFinalizer(types.CSPCFinalizer)
 
+	// ToDo: Move this to openebs/api builder
+	// Create label selector to fill in BDC spec.
+	if ok {
+		ls := &metav1.LabelSelector{
+			MatchLabels: map[string]string{types.BlockDeviceTagLabelKey: value},
+		}
+		newBDCObj.Spec.Selector = ls
+	}
+
 	_, err = ac.clientset.OpenebsV1alpha1().BlockDeviceClaims(ac.Namespace).Create(newBDCObj)
 	if k8serror.IsAlreadyExists(err) {
 		klog.Infof("BDC for BD {%s} already created", bdObj.Name)
@@ -181,6 +217,29 @@ func (ac *Config) ClaimBD(bdObj openebsio.BlockDevice) error {
 		return errors.Wrapf(err, "failed to create block device claim for bd {%s}", bdObj.Name)
 	}
 	return nil
+}
+
+// getAllowedTagMap returns a map of the allowed BD tags
+// Example :
+// If the CSPC annotation is passed and following is the BD tag annotation
+//
+// cstor.openebs.io/allowed-bd-tags:fast,slow
+//
+// Then, a map {"fast":true,"slow":true} is returned.
+func getAllowedTagMap(cspcAnnotation map[string]string) map[string]bool {
+	allowedTagsMap := make(map[string]bool)
+	allowedTags := cspcAnnotation[CStorBDTagAnnotationKey]
+	if strings.TrimSpace(allowedTags) == "" {
+		return allowedTagsMap
+	}
+	allowedTagsList := strings.Split(allowedTags, ",")
+	for _, v := range allowedTagsList {
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		allowedTagsMap[v] = true
+	}
+	return allowedTagsMap
 }
 
 // IsClaimedBDUsable returns true if the passed BD is already claimed and can be

--- a/pkg/cspc/algorithm/select_node.go
+++ b/pkg/cspc/algorithm/select_node.go
@@ -34,7 +34,7 @@ const (
 	unit = 1024
 	// CStorBDTagAnnotationKey is the annotation key for CSPC allowed BD tags
 	// ToDo: Move to API type (openebs/api)
-	CStorBDTagAnnotationKey = "cstor.openebs.io/allowed-bd-tags"
+	OpenEBSAllowedBDTagKey = "openebs.io/allowed-bd-tags"
 )
 
 // SelectNode returns a node where pool should be created.
@@ -185,7 +185,7 @@ func (ac *Config) ClaimBD(bdObj openebsio.BlockDevice) error {
 		if !allowedBDTags[strings.TrimSpace(value)] {
 			return errors.Errorf("cannot use bd {%s} as it has tag %s but "+
 				"cspc has allowed bd tags as %s",
-				bdObj.Name, value, ac.CSPC.GetAnnotations()[CStorBDTagAnnotationKey])
+				bdObj.Name, value, ac.CSPC.GetAnnotations()[OpenEBSAllowedBDTagKey])
 		}
 	}
 
@@ -228,7 +228,7 @@ func (ac *Config) ClaimBD(bdObj openebsio.BlockDevice) error {
 // Then, a map {"fast":true,"slow":true} is returned.
 func getAllowedTagMap(cspcAnnotation map[string]string) map[string]bool {
 	allowedTagsMap := make(map[string]bool)
-	allowedTags := cspcAnnotation[CStorBDTagAnnotationKey]
+	allowedTags := cspcAnnotation[OpenEBSAllowedBDTagKey]
 	if strings.TrimSpace(allowedTags) == "" {
 		return allowedTagsMap
 	}

--- a/pkg/cspc/algorithm/select_node_test.go
+++ b/pkg/cspc/algorithm/select_node_test.go
@@ -387,7 +387,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #1",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "fast,slow"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "fast,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -395,7 +395,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #2",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "fast,slow"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "fast,slow"},
 			},
 			want: map[string]bool{"slow": true, "fast": true},
 		},
@@ -419,7 +419,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #5 -- Improper format 1",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,slow,,"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,slow,,"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -427,7 +427,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #6 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,slow"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -435,7 +435,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #7 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,,slow"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -443,7 +443,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #7 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "this is improper"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "this is improper"},
 			},
 			want: map[string]bool{"this is improper": true},
 		},

--- a/pkg/cspc/algorithm/select_node_test.go
+++ b/pkg/cspc/algorithm/select_node_test.go
@@ -387,7 +387,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #1",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: "fast,slow"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "fast,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -395,7 +395,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #2",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: "fast,slow"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "fast,slow"},
 			},
 			want: map[string]bool{"slow": true, "fast": true},
 		},
@@ -419,7 +419,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #5 -- Improper format 1",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: ",fast,slow,,"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,slow,,"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -427,7 +427,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #6 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: ",fast,slow"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -435,7 +435,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #7 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: ",fast,,slow"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -443,7 +443,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #7 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: "this is improper"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "this is improper"},
 			},
 			want: map[string]bool{"this is improper": true},
 		},

--- a/pkg/snapshot/snapshottest/snapshot.go
+++ b/pkg/snapshot/snapshottest/snapshot.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/volume-rpc/targetserver/config.go
+++ b/pkg/volume-rpc/targetserver/config.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	openebsapis "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
@@ -413,12 +414,17 @@ func validateBlockDevice(bd *openebsapis.BlockDevice, hostName string) error {
 			bd.Labels[types.HostNameLabelKey],
 		)
 	}
+
+	// If the BD tag is present on BD and the value is empty then
+	// this BD is not a valid BD for provisioning.
 	if v, found := bd.Labels[types.BlockDeviceTagLabelKey]; found {
-		return errors.Errorf(
-			"block device %s is tagged with a value %s and cannot be used",
-			bd.Name,
-			v,
-		)
+		if strings.TrimSpace(v) == "" {
+			return errors.Errorf(
+				"block device %s is tagged with a value %s and cannot be used",
+				bd.Name,
+				v,
+			)
+		}
 	}
 
 	return nil

--- a/pkg/webhook/cspc_operations.go
+++ b/pkg/webhook/cspc_operations.go
@@ -38,7 +38,7 @@ const (
 	dataRG       = "data"
 	writeCacheRG = "writeCache"
 	// ToDo: Move to API type (openebs/api)
-	CStorBDTagAnnotationKey = "cstor.openebs.io/allowed-bd-tags"
+	OpenEBSAllowedBDTagKey = "openebs.io/allowed-bd-tags"
 )
 
 // PoolOperations contains old and new CSPC to validate for pool
@@ -487,7 +487,7 @@ func (pOps *PoolOperations) ClaimBD(newBdObj *openebsapis.BlockDevice, oldBD str
 		if !allowedBDTags[strings.TrimSpace(value)] {
 			return errors.Errorf("cannot use bd {%s} as it has tag %s but "+
 				"cspc has allowed bd tags as %s",
-				newBdObj.Name, value, pOps.NewCSPC.GetAnnotations()[CStorBDTagAnnotationKey])
+				newBdObj.Name, value, pOps.NewCSPC.GetAnnotations()[OpenEBSAllowedBDTagKey])
 		}
 	}
 
@@ -541,7 +541,7 @@ func (pOps *PoolOperations) ClaimBD(newBdObj *openebsapis.BlockDevice, oldBD str
 // Then, a map {"fast":true,"slow":true} is returned.
 func getAllowedTagMap(cspcAnnotation map[string]string) map[string]bool {
 	allowedTagsMap := make(map[string]bool)
-	allowedTags := cspcAnnotation[CStorBDTagAnnotationKey]
+	allowedTags := cspcAnnotation[OpenEBSAllowedBDTagKey]
 	if strings.TrimSpace(allowedTags) == "" {
 		return allowedTagsMap
 	}

--- a/pkg/webhook/cspc_operations.go
+++ b/pkg/webhook/cspc_operations.go
@@ -37,8 +37,6 @@ import (
 const (
 	dataRG       = "data"
 	writeCacheRG = "writeCache"
-	// ToDo: Move to API type (openebs/api)
-	OpenEBSAllowedBDTagKey = "openebs.io/allowed-bd-tags"
 )
 
 // PoolOperations contains old and new CSPC to validate for pool
@@ -487,7 +485,7 @@ func (pOps *PoolOperations) ClaimBD(newBdObj *openebsapis.BlockDevice, oldBD str
 		if !allowedBDTags[strings.TrimSpace(value)] {
 			return errors.Errorf("cannot use bd {%s} as it has tag %s but "+
 				"cspc has allowed bd tags as %s",
-				newBdObj.Name, value, pOps.NewCSPC.GetAnnotations()[OpenEBSAllowedBDTagKey])
+				newBdObj.Name, value, pOps.NewCSPC.GetAnnotations()[types.OpenEBSAllowedBDTagKey])
 		}
 	}
 
@@ -541,7 +539,7 @@ func (pOps *PoolOperations) ClaimBD(newBdObj *openebsapis.BlockDevice, oldBD str
 // Then, a map {"fast":true,"slow":true} is returned.
 func getAllowedTagMap(cspcAnnotation map[string]string) map[string]bool {
 	allowedTagsMap := make(map[string]bool)
-	allowedTags := cspcAnnotation[OpenEBSAllowedBDTagKey]
+	allowedTags := cspcAnnotation[types.OpenEBSAllowedBDTagKey]
 	if strings.TrimSpace(allowedTags) == "" {
 		return allowedTagsMap
 	}

--- a/pkg/webhook/cspc_operations.go
+++ b/pkg/webhook/cspc_operations.go
@@ -19,6 +19,7 @@ package webhook
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	openebsapis "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
@@ -36,6 +37,8 @@ import (
 const (
 	dataRG       = "data"
 	writeCacheRG = "writeCache"
+	// ToDo: Move to API type (openebs/api)
+	CStorBDTagAnnotationKey = "cstor.openebs.io/allowed-bd-tags"
 )
 
 // PoolOperations contains old and new CSPC to validate for pool
@@ -461,7 +464,33 @@ func getBDOwnerReference(cspc *cstor.CStorPoolCluster) []metav1.OwnerReference {
 }
 
 // ClaimBD claims a given BlockDevice
+// ToDo: The BD Claim functionality has code repetition.
+// Need to think about packaging and refactor.
 func (pOps *PoolOperations) ClaimBD(newBdObj *openebsapis.BlockDevice, oldBD string) error {
+
+	// If the BD has a BD tag present then we need to decide whether
+	// cStor can use it or not.
+	// If there is not BD tag present on BD then still the BD is safe to use.
+	value, ok := newBdObj.Labels[types.BlockDeviceTagLabelKey]
+	var allowedBDTags map[string]bool
+	if ok {
+		// If the BD tag value is empty -- cStor cannot use it.
+		if strings.TrimSpace(value) == "" {
+			return errors.Errorf("failed to create block device "+
+				"claim for bd {%s} as it has empty value for bd tag", newBdObj.Name)
+		}
+
+		// If the BD tag in the BD is present in allowed annotations on CSPC then
+		// it means that this BD can be considered in provisioning else it should not
+		// be considered
+		allowedBDTags = getAllowedTagMap(pOps.NewCSPC.GetAnnotations())
+		if !allowedBDTags[strings.TrimSpace(value)] {
+			return errors.Errorf("cannot use bd {%s} as it has tag %s but "+
+				"cspc has allowed bd tags as %s",
+				newBdObj.Name, value, pOps.NewCSPC.GetAnnotations()[CStorBDTagAnnotationKey])
+		}
+	}
+
 	newBDCObj := openebsapis.NewBlockDeviceClaim().
 		WithName("bdc-cstor-" + string(newBdObj.UID)).
 		WithNamespace(newBdObj.Namespace).
@@ -472,6 +501,14 @@ func (pOps *PoolOperations) ClaimBD(newBdObj *openebsapis.BlockDevice, oldBD str
 		WithCapacity(resource.MustParse(ByteCount(newBdObj.Spec.Capacity.Storage))).
 		WithCSPCOwnerReference(getBDOwnerReference(pOps.OldCSPC)[0]).
 		WithFinalizer(types.CSPCFinalizer)
+	// ToDo: Move this to openebs/api builder
+	// Create label selector to fill in BDC spec.
+	if ok {
+		ls := &metav1.LabelSelector{
+			MatchLabels: map[string]string{types.BlockDeviceTagLabelKey: value},
+		}
+		newBDCObj.Spec.Selector = ls
+	}
 
 	bdcClient := pOps.clientset.OpenebsV1alpha1().BlockDeviceClaims(newBdObj.Namespace)
 	bdcObj, err := bdcClient.Get(newBDCObj.Name, v1.GetOptions{})
@@ -493,6 +530,29 @@ func (pOps *PoolOperations) ClaimBD(newBdObj *openebsapis.BlockDevice, oldBD str
 	_, err = bdcClient.
 		Update(bdcObj)
 	return err
+}
+
+// getAllowedTagMap returns a map of the allowed BD tags
+// Example :
+// If the CSPC annotation is passed and following is the BD tag annotation
+//
+// cstor.openebs.io/allowed-bd-tags:fast,slow
+//
+// Then, a map {"fast":true,"slow":true} is returned.
+func getAllowedTagMap(cspcAnnotation map[string]string) map[string]bool {
+	allowedTagsMap := make(map[string]bool)
+	allowedTags := cspcAnnotation[CStorBDTagAnnotationKey]
+	if strings.TrimSpace(allowedTags) == "" {
+		return allowedTagsMap
+	}
+	allowedTagsList := strings.Split(allowedTags, ",")
+	for _, v := range allowedTagsList {
+		if strings.TrimSpace(v) == "" {
+			continue
+		}
+		allowedTagsMap[v] = true
+	}
+	return allowedTagsMap
 }
 
 // GetNewBDFromRaidGroups returns a map of new successor bd to old bd for replacement in a raid group

--- a/pkg/webhook/cspc_operations_test.go
+++ b/pkg/webhook/cspc_operations_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package webhook
 
 import (
+	"github.com/openebs/api/pkg/apis/types"
 	"reflect"
 	"testing"
 
@@ -779,7 +780,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #1",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "fast,slow"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "fast,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -787,7 +788,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #2",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "fast,slow"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "fast,slow"},
 			},
 			want: map[string]bool{"slow": true, "fast": true},
 		},
@@ -811,7 +812,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #5 -- Improper format 1",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,slow,,"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,slow,,"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -819,7 +820,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #6 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,slow"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -827,7 +828,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #7 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,,slow"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -835,7 +836,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #7 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "this is improper"},
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "this is improper"},
 			},
 			want: map[string]bool{"this is improper": true},
 		},

--- a/pkg/webhook/cspc_operations_test.go
+++ b/pkg/webhook/cspc_operations_test.go
@@ -779,7 +779,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #1",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: "fast,slow"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "fast,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -787,7 +787,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #2",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: "fast,slow"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "fast,slow"},
 			},
 			want: map[string]bool{"slow": true, "fast": true},
 		},
@@ -811,7 +811,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #5 -- Improper format 1",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: ",fast,slow,,"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,slow,,"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -819,7 +819,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #6 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: ",fast,slow"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -827,7 +827,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #7 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: ",fast,,slow"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: ",fast,,slow"},
 			},
 			want: map[string]bool{"fast": true, "slow": true},
 		},
@@ -835,7 +835,7 @@ func Test_getAllowedTagMap(t *testing.T) {
 		{
 			name: "Test case #7 -- Improper format 2",
 			args: args{
-				cspcAnnotation: map[string]string{CStorBDTagAnnotationKey: "this is improper"},
+				cspcAnnotation: map[string]string{OpenEBSAllowedBDTagKey: "this is improper"},
 			},
 			want: map[string]bool{"this is improper": true},
 		},

--- a/pkg/zcmd/zfs/stats/stats.go
+++ b/pkg/zcmd/zfs/stats/stats.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/cstorvolume/provisioing/provisioning_utils.go
+++ b/tests/cstorvolume/provisioing/provisioning_utils.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/vendor/github.com/openebs/api/pkg/apis/types/types.go
+++ b/vendor/github.com/openebs/api/pkg/apis/types/types.go
@@ -121,4 +121,10 @@ const (
 	// OpenEBSCStorExistingPoolName is the name of the cstor pool already present on
 	// the disk that needs to be imported and renamed
 	OpenEBSCStorExistingPoolName = "import.cspi.cstor.openebs.io/existing-pool-name"
+
+	// OpenEBSCStorAllowedBDTagKey is the annotation key present that decides whether
+	// a particular BD with a tag is allowed in storage provisioning or not.
+	// This annotation can be used on SPC or CSPC to allow a particular BD(s) with tag
+	// for provisioning.
+	OpenEBSAllowedBDTagKey = "openebs.io/allowed-bd-tags"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932
+# github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f
 github.com/openebs/api/pkg/apis/cstor
 github.com/openebs/api/pkg/apis/cstor/v1
 github.com/openebs/api/pkg/apis/openebs.io


### PR DESCRIPTION
This PR adds capability to specify allowed BD tags on CSPC via
annotations.
The annotation key is `cstor.openebs.io/allowed-bd-tags` and allowed value
is comma separated strings.
For example "fast,slow" is a possible value and in this case CSPC provisioner
will reject BDs that have a BD tag (`openebs.io/block-device-tag`) present on
it and the value is other than fast or slow.

Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>