### PR TITLE
cherry_pick(goversion,license,bd-tag): cherry pick PRs  in 2.0.x branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.6
+        go-version: 1.14.7
       id: go
 
     - name: Check out code into the Go module directory
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13.6
+        go-version: 1.14.7
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: verify license
-      run: make license-check-go
+      run: make license-check
 
     - name: verify dependencies
       run: make deps

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,11 +16,15 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: verify license
+      run: make license-check-go
+
     - name: verify dependencies
       run: make deps
 
     - name: verify tests
       run: make test
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ dist: bionic
 language: go
 
 go:
-  - 1.13.x
+  - 1.14.7
 
 env:
   global:

--- a/Makefile
+++ b/Makefile
@@ -214,3 +214,19 @@ deploy-images:
 gen-api-docs:
 	@echo ">> generating cstor 'v1' apis docs"
 	go run github.com/ahmetb/gen-crd-api-reference-docs -api-dir ../api/pkg/apis/cstor/v1 -config hack/api-docs/config.json -template-dir hack/api-docs/template -out-file docs/api-references/apis.md
+
+.PHONY: build.common
+build.common: license-check-go
+
+.PHONY: license-check-go
+license-check-go:
+	@echo "--> Checking license header..."
+	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*' ! -path './pkg/signals/*' ! -path './pkg/debug/*' ) ; do \
+               awk 'NR<=3' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
+       done); \
+       if [ -n "$${licRes}" ]; then \
+               echo "license header checking failed:"; echo "$${licRes}"; \
+               exit 1; \
+       fi
+	@echo "--> Done checking license."
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -215,14 +215,12 @@ gen-api-docs:
 	@echo ">> generating cstor 'v1' apis docs"
 	go run github.com/ahmetb/gen-crd-api-reference-docs -api-dir ../api/pkg/apis/cstor/v1 -config hack/api-docs/config.json -template-dir hack/api-docs/template -out-file docs/api-references/apis.md
 
-.PHONY: build.common
-build.common: license-check-go
 
-.PHONY: license-check-go
-license-check-go:
+.PHONY: license-check
+license-check:
 	@echo "--> Checking license header..."
-	@licRes=$$(for file in $$(find . -type f -iname '*.go' ! -path './vendor/*' ! -path './pkg/signals/*' ! -path './pkg/debug/*' ) ; do \
-               awk 'NR<=3' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
+	@licRes=$$(for file in $$(find . -type f -regex '.*\.sh\|.*\.go\|.*Docker.*\|.*\Makefile*' ! -path './vendor/*' ) ; do \
+               awk 'NR<=5' $$file | grep -Eq "(Copyright|generated|GENERATED)" || echo $$file; \
        done); \
        if [ -n "$${licRes}" ]; then \
                echo "license header checking failed:"; echo "$${licRes}"; \

--- a/build/cspc-operator/Dockerfile
+++ b/build/cspc-operator/Dockerfile
@@ -1,4 +1,16 @@
 #
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/
 # This Dockerfile builds a recent cspc-operator using the latest binary from
 # cspc-operator  releases.
 #

--- a/build/cstor-webhook/Dockerfile
+++ b/build/cstor-webhook/Dockerfile
@@ -1,3 +1,15 @@
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/
 FROM ubuntu:18.04
 
 RUN apt-get update && apt-get install -y \

--- a/build/cvc-operator/Dockerfile
+++ b/build/cvc-operator/Dockerfile
@@ -1,3 +1,15 @@
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/
 FROM alpine:3.11.5
 
 RUN apk add --no-cache \

--- a/build/cvc-operator/Dockerfile.arm64
+++ b/build/cvc-operator/Dockerfile.arm64
@@ -1,3 +1,15 @@
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0	
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/
 #Make the base image configurable. If BASE IMAGES is not provided
 #docker command will fail
 ARG BASE_IMAGE=arm64v8/alpine

--- a/build/cvc-operator/entrypoint.sh
+++ b/build/cvc-operator/entrypoint.sh
@@ -1,3 +1,15 @@
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/
 #!/bin/sh
 
 set -ex

--- a/build/pool-manager/Dockerfile
+++ b/build/pool-manager/Dockerfile
@@ -1,4 +1,16 @@
 #
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/
 # This Dockerfile builds a recent cspi-mgmt using the latest binary from
 # cspi-mgmt  releases.
 #

--- a/build/pool-manager/entrypoint.sh
+++ b/build/pool-manager/entrypoint.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/
 
 set -ex
 

--- a/build/volume-manager/Dockerfile
+++ b/build/volume-manager/Dockerfile
@@ -1,4 +1,15 @@
-#
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/#
 # This Dockerfile builds a recent cstor-volume-mgmt using the latest binary from
 # cstor-volume-mgmt  releases.
 #

--- a/build/volume-manager/Dockerfile.arm64
+++ b/build/volume-manager/Dockerfile.arm64
@@ -1,3 +1,15 @@
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/
 #
 # This Dockerfile builds a recent cstor-volume-mgmt using the latest binary from
 # cstor-volume-mgmt  releases.

--- a/build/volume-manager/entrypoint.sh
+++ b/build/volume-manager/entrypoint.sh
@@ -1,3 +1,15 @@
+#/*
+#Copyright 2020 The OpenEBS Authors
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+#	http://www.apache.org/licenses/LICENSE-2.0
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+#*/
 #!/bin/sh
 
 set -ex

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
-	github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932
+	github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -391,6 +391,8 @@ github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c h1:fZmO/A7BnxFAg9y1
 github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932 h1:YzV1nspFTKrCa7c2XeWPcrU9KRvV9Ul9Yu9SLHqldas=
 github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
+github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f h1:ebsHrWNo+Ypp5C9eKMC8lX9z9OrZxCUkWAzN2otwfek=
+github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.1.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/controllers/cspc-controller/util/cspc_util_test.go
+++ b/pkg/controllers/cspc-controller/util/cspc_util_test.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/controllers/cspc-controller/util/cspc_util_test.go
+++ b/pkg/controllers/cspc-controller/util/cspc_util_test.go
@@ -1,3 +1,17 @@
+/*
+Copyright 2020 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package util
 
 import (

--- a/pkg/controllers/cstorvolumeconfig/volume_operations_test.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations_test.go
@@ -1,1 +1,15 @@
+/*
+Copyright 2020 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package cstorvolumeconfig

--- a/pkg/controllers/cstorvolumeconfig/volume_operations_test.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations_test.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/cspc/algorithm/select_node_test.go
+++ b/pkg/cspc/algorithm/select_node_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/openebs/api/pkg/apis/types"
 	openebsFakeClientset "github.com/openebs/api/pkg/client/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
@@ -370,6 +370,88 @@ func TestConfig_ClaimBD(t *testing.T) {
 			if isBdcCreated != tt.isBdcCreated {
 				t.Errorf("Config.ClaimBD() error = %v, wantErr %v", isBdcCreated, tt.isBdcCreated)
 				return
+			}
+		})
+	}
+}
+
+func Test_getAllowedTagMap(t *testing.T) {
+	type args struct {
+		cspcAnnotation map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]bool
+	}{
+		{
+			name: "Test case #1",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "fast,slow"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #2",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "fast,slow"},
+			},
+			want: map[string]bool{"slow": true, "fast": true},
+		},
+
+		{
+			name: "Test case #3 -- Nil Annotations",
+			args: args{
+				cspcAnnotation: nil,
+			},
+			want: map[string]bool{},
+		},
+
+		{
+			name: "Test case #4 -- No BD tag Annotations",
+			args: args{
+				cspcAnnotation: map[string]string{"some-other-annotation-key": "awesome-openebs"},
+			},
+			want: map[string]bool{},
+		},
+
+		{
+			name: "Test case #5 -- Improper format 1",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,slow,,"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #6 -- Improper format 2",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,slow"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #7 -- Improper format 2",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,,slow"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #7 -- Improper format 2",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "this is improper"},
+			},
+			want: map[string]bool{"this is improper": true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAllowedTagMap(tt.args.cspcAnnotation); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAllowedTagMap() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/snapshot/snapshottest/snapshot.go
+++ b/pkg/snapshot/snapshottest/snapshot.go
@@ -1,3 +1,17 @@
+/*
+Copyright 2020 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package snapshottest
 
 import (

--- a/pkg/snapshot/snapshottest/snapshot.go
+++ b/pkg/snapshot/snapshottest/snapshot.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -1,3 +1,17 @@
+/*
+Copyright 2020 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package version
 
 import (

--- a/pkg/volume-rpc/targetserver/config.go
+++ b/pkg/volume-rpc/targetserver/config.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/volume-rpc/targetserver/config.go
+++ b/pkg/volume-rpc/targetserver/config.go
@@ -1,3 +1,17 @@
+/*
+Copyright 2020 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package targetserver
 
 import (

--- a/pkg/webhook/cspc.go
+++ b/pkg/webhook/cspc.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
 	openebsapis "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
@@ -413,13 +414,17 @@ func validateBlockDevice(bd *openebsapis.BlockDevice, hostName string) error {
 			bd.Labels[types.HostNameLabelKey],
 		)
 	}
-	
+
+	// If the BD tag is present on BD and the value is empty then
+	// this BD is not a valid BD for provisioning.
 	if v, found := bd.Labels[types.BlockDeviceTagLabelKey]; found {
-		return errors.Errorf(
-			"block device %s is tagged with a value %s and cannot be used",
-			bd.Name,
-			v,
-		)
+		if strings.TrimSpace(v) == "" {
+			return errors.Errorf(
+				"block device %s is tagged with a value %s and cannot be used",
+				bd.Name,
+				v,
+			)
+		}
 	}
 
 	return nil

--- a/pkg/webhook/cspc_operations_test.go
+++ b/pkg/webhook/cspc_operations_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package webhook
 
 import (
+	"github.com/openebs/api/pkg/apis/types"
+	"reflect"
 	"testing"
 
 	cstor "github.com/openebs/api/pkg/apis/cstor/v1"
@@ -761,6 +763,88 @@ func TestValidateRaidGroupChanges(t *testing.T) {
 			}
 			if !test.expectedError && err != nil {
 				t.Errorf("test %s failed expectedError not to be error but got error %v", name, err)
+			}
+		})
+	}
+}
+
+func Test_getAllowedTagMap(t *testing.T) {
+	type args struct {
+		cspcAnnotation map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want map[string]bool
+	}{
+		{
+			name: "Test case #1",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "fast,slow"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #2",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "fast,slow"},
+			},
+			want: map[string]bool{"slow": true, "fast": true},
+		},
+
+		{
+			name: "Test case #3 -- Nil Annotations",
+			args: args{
+				cspcAnnotation: nil,
+			},
+			want: map[string]bool{},
+		},
+
+		{
+			name: "Test case #4 -- No BD tag Annotations",
+			args: args{
+				cspcAnnotation: map[string]string{"some-other-annotation-key": "awesome-openebs"},
+			},
+			want: map[string]bool{},
+		},
+
+		{
+			name: "Test case #5 -- Improper format 1",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,slow,,"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #6 -- Improper format 2",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,slow"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #7 -- Improper format 2",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: ",fast,,slow"},
+			},
+			want: map[string]bool{"fast": true, "slow": true},
+		},
+
+		{
+			name: "Test case #7 -- Improper format 2",
+			args: args{
+				cspcAnnotation: map[string]string{types.OpenEBSAllowedBDTagKey: "this is improper"},
+			},
+			want: map[string]bool{"this is improper": true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getAllowedTagMap(tt.args.cspcAnnotation); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAllowedTagMap() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/zcmd/zfs/stats/stats.go
+++ b/pkg/zcmd/zfs/stats/stats.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/pkg/zcmd/zfs/stats/stats.go
+++ b/pkg/zcmd/zfs/stats/stats.go
@@ -1,3 +1,17 @@
+/*
+Copyright 2020 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package vstats
 
 // ZFSStats used to represents zfs dataset stats

--- a/tests/cstorvolume/provisioing/provisioning_utils.go
+++ b/tests/cstorvolume/provisioing/provisioning_utils.go
@@ -5,7 +5,7 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 	http://www.apache.org/licenses/LICENSE-2.0
-	
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/tests/cstorvolume/provisioing/provisioning_utils.go
+++ b/tests/cstorvolume/provisioing/provisioning_utils.go
@@ -1,3 +1,17 @@
+/*
+Copyright 2020 The OpenEBS Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+	
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package provisioning
 
 import (

--- a/vendor/github.com/openebs/api/pkg/apis/types/types.go
+++ b/vendor/github.com/openebs/api/pkg/apis/types/types.go
@@ -121,4 +121,10 @@ const (
 	// OpenEBSCStorExistingPoolName is the name of the cstor pool already present on
 	// the disk that needs to be imported and renamed
 	OpenEBSCStorExistingPoolName = "import.cspi.cstor.openebs.io/existing-pool-name"
+
+	// OpenEBSCStorAllowedBDTagKey is the annotation key present that decides whether
+	// a particular BD with a tag is allowed in storage provisioning or not.
+	// This annotation can be used on SPC or CSPC to allow a particular BD(s) with tag
+	// for provisioning.
+	OpenEBSAllowedBDTagKey = "openebs.io/allowed-bd-tags"
 )

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -82,7 +82,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932
+# github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f
 github.com/openebs/api/pkg/apis/cstor
 github.com/openebs/api/pkg/apis/cstor/v1
 github.com/openebs/api/pkg/apis/openebs.io


### PR DESCRIPTION
This PR is a cherry-pick PR for the following PRs: 

https://github.com/openebs/cstor-operators/pull/169

The following two PRs were required to avoid rebase changes as license headers were added in go files: 
https://github.com/openebs/cstor-operators/pull/170
https://github.com/openebs/cstor-operators/pull/171

The following is bd-tag PR 
https://github.com/openebs/cstor-operators/pull/172
This cherry-pick required a rebase
