### PR TITLE
feat(backup & restore): add v1 support for backup and restore

### DIFF
--- a/deploy/crds/all_cstor_crds.yaml
+++ b/deploy/crds/all_cstor_crds.yaml
@@ -6,6 +6,184 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.9
   creationTimestamp: null
+  name: cstorbackups.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.volumeName
+    description: Name of the volume for which this backup is destined
+    name: Volume
+    type: string
+  - JSONPath: .spec.backupName
+    description: Name of the backup or scheduled backup
+    name: Backup/Schedule
+    type: string
+  - JSONPath: .status
+    description: Identifies the phase of the backup
+    name: Status
+    type: string
+  group: cstor.openebs.io
+  names:
+    kind: CStorBackup
+    listKind: CStorBackupList
+    plural: cstorbackups
+    shortNames:
+    - cbackup
+    singular: cstorbackup
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorBackup describes a cstor backup resource created as a custom
+        resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorBackupSpec is the spec for a CStorBackup resource
+          properties:
+            backupDest:
+              description: BackupDest is the remote address for backup transfer
+              type: string
+            backupName:
+              description: BackupName is a name of the backup or scheduled backup
+              type: string
+            localSnap:
+              description: LocalSnap is flag to enable local snapshot only
+              type: boolean
+            prevSnapName:
+              description: PrevSnapName is the last completed-backup's snapshot name
+              type: string
+            snapName:
+              description: SnapName is a name of the current backup snapshot
+              type: string
+            volumeName:
+              description: VolumeName is a name of the volume for which this backup
+                is destined
+              type: string
+          required:
+          - backupName
+          - snapName
+          - volumeName
+          type: object
+        status:
+          description: CStorBackupStatus is to hold status of backup
+          type: string
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorcompletedbackups.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.volumeName
+    description: Volume name on which backup is performed
+    name: Volume
+    type: string
+  - JSONPath: .spec.backupName
+    description: Name of the backup or scheduled backup
+    name: Backup/Schedule
+    type: string
+  - JSONPath: .spec.lastSnapName
+    description: Last successfully backup snapshot
+    name: LastSnap
+    type: string
+  group: cstor.openebs.io
+  names:
+    kind: CStorCompletedBackup
+    listKind: CStorCompletedBackupList
+    plural: cstorcompletedbackups
+    shortNames:
+    - ccompletedbackup
+    singular: cstorcompletedbackup
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorCompletedBackup describes a cstor completed-backup resource
+        created as custom resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorCompletedBackupSpec is the spec for a CStorBackup resource
+          properties:
+            backupName:
+              description: BackupName is a name of the backup or scheduled backup
+              type: string
+            lastSnapName:
+              description: LastSnapName is the last completed-backup's snapshot name
+              type: string
+            secondLastSnapName:
+              description: SecondLastSnapName is a name of the second last 'successfully'
+                completed-backup's snapshot
+              type: string
+            volumeName:
+              description: VolumeName is a name of the volume for which this backup
+                is destined
+              type: string
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
   name: cstorpoolclusters.cstor.openebs.io
 spec:
   additionalPrinterColumns:
@@ -929,6 +1107,115 @@ spec:
                   type: string
               type: object
           type: object
+      required:
+      - spec
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.9
+  creationTimestamp: null
+  name: cstorrestores.cstor.openebs.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.restoreName
+    description: Name of the snapshot which is restored
+    name: Backup
+    type: string
+  - JSONPath: .spec.volumeName
+    description: Volume on which restore is performed
+    name: Volume
+    type: string
+  - JSONPath: .status
+    description: Identifies the state of the restore
+    name: Status
+    type: string
+  group: cstor.openebs.io
+  names:
+    kind: CStorRestore
+    listKind: CStorRestoreList
+    plural: cstorrestores
+    shortNames:
+    - crestore
+    singular: cstorrestore
+  preserveUnknownFields: false
+  scope: Namespaced
+  subresources: {}
+  validation:
+    openAPIV3Schema:
+      description: CStorRestore describes a cstor restore resource created as a custom
+        resource
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: CStorRestoreSpec is the spec for a CStorRestore resource
+          properties:
+            localRestore:
+              description: Local defines whether restore is from local/remote
+              type: boolean
+            maxretrycount:
+              description: MaxRestoreRetryCount is the maximum number of attempt,
+                will be performed to restore
+              type: integer
+            restoreName:
+              description: RestoreName holds restore name
+              type: string
+            restoreSrc:
+              description: RestoreSrc can be ip:port in case of restore from remote
+                or volumeName in case of local restore
+              type: string
+            retrycount:
+              description: RetryCount represents the number of restore attempts performed
+                for the restore
+              type: integer
+            size:
+              anyOf:
+              - type: integer
+              - type: string
+              description: Size represents the size of a snapshot to restore
+              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+              x-kubernetes-int-or-string: true
+            storageClass:
+              description: StorageClass represents name of StorageClass of restore
+                volume
+              type: string
+            volumeName:
+              description: VolumeName is used to restore the data to corresponding
+                volume
+              type: string
+          required:
+          - restoreName
+          - restoreSrc
+          - volumeName
+          type: object
+        status:
+          description: CStorRestoreStatus is to hold result of action.
+          type: string
       required:
       - spec
       type: object
@@ -2489,96 +2776,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: cstorbackups.openebs.io
-spec:
-  group: openebs.io
-  version: v1alpha1
-  scope: Namespaced
-  names:
-    plural: cstorbackups
-    singular: cstorbackup
-    kind: CStorBackup
-    shortNames:
-    - cbkp
-    - cbkps
-    - cbackups
-    - cbackup
-  additionalPrinterColumns:
-    - JSONPath: .spec.volumeName
-      name: volume
-      description: volume on which backup performed
-      type: string
-    - JSONPath: .spec.backupName
-      name: backup/schedule
-      description: Backup/schedule name
-      type: string
-    - JSONPath: .status
-      name: Status
-      description: Backup status
-      type: string
-
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: cstorcompletedbackups.openebs.io
-spec:
-  group: openebs.io
-  version: v1alpha1
-  scope: Namespaced
-  names:
-    plural: cstorcompletedbackups
-    singular: cstorcompletedbackup
-    kind: CStorCompletedBackup
-    shortNames:
-    - cbkpc
-    - cbackupcompleted
-  additionalPrinterColumns:
-    - JSONPath: .spec.volumeName
-      name: volume
-      description: volume on which backup performed
-      type: string
-    - JSONPath: .spec.backupName
-      name: backup/schedule
-      description: Backup/schedule name
-      type: string
-    - JSONPath: .spec.prevSnapName
-      name: lastSnap
-      description: Last successful backup snapshot
-      type: string
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: cstorrestores.openebs.io
-spec:
-  group: openebs.io
-  version: v1alpha1
-  scope: Namespaced
-  names:
-    plural: cstorrestores
-    singular: cstorrestore
-    kind: CStorRestore
-    shortNames:
-    - crst
-    - crsts
-    - crestores
-    - crestore
-  additionalPrinterColumns:
-    - JSONPath: .spec.restoreName
-      name: backup
-      description: backup name which is  restored
-      type: string
-    - JSONPath: .spec.volumeName
-      name: volume
-      description: volume on which restore performed
-      type: string
-    - JSONPath: .status
-      name: Status
-      description: Restore status
-      type: string
----

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/evanphx/json-patch v4.5.0+incompatible // indirect
 	github.com/ghodss/yaml v1.0.0
+	github.com/hashicorp/go-version v1.2.1
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -393,8 +393,6 @@ github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c h1:fZmO/A7BnxFAg9y1
 github.com/openebs/api v1.12.1-0.20200805040335-b9bd4809e80c/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932 h1:YzV1nspFTKrCa7c2XeWPcrU9KRvV9Ul9Yu9SLHqldas=
 github.com/openebs/api v1.12.1-0.20200813113856-a86aa610f932/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
-github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f h1:ebsHrWNo+Ypp5C9eKMC8lX9z9OrZxCUkWAzN2otwfek=
-github.com/openebs/api v1.12.1-0.20200908020958-c9b104663c7f/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/openebs/api v1.12.1-0.20200929170750-b9ef3e718ef4 h1:/NOmEFJT2aBoAwGMmuS72t7P8u+HNtmGF7NKDwS/Rtk=
 github.com/openebs/api v1.12.1-0.20200929170750-b9ef3e718ef4/go.mod h1:TASujm6H1LGdx43MN7Dab1xdAqR7MVU8bsS74Ywop5w=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
@@ -411,7 +409,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/pquerna/ffjson v0.0.0-20180717144149-af8b230fcd20/go.mod h1:YARuvh7BUWHNhzDq2OM5tzR2RiCcN2D7sapiKyCel/M=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
-github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -427,7 +424,6 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
 github.com/russross/blackfriday v0.0.0-20170610170232-067529f716f4/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
-github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/ryanuber/columnize v2.1.0+incompatible h1:j1Wcmh8OrK4Q7GXY+V7SVSY8nUWQxHW5TkBe7YUl+2s=
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -675,7 +671,6 @@ gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
@@ -725,7 +720,6 @@ k8s.io/component-base v0.17.3/go.mod h1:GeQf4BrgelWm64PXkIXiPh/XS0hnO42d9gx9BtbZ
 k8s.io/cri-api v0.17.4-beta.0/go.mod h1:X1sbHmuXhwaHs9xxYffLqJogVsnI+f6cPRcgPel7ywM=
 k8s.io/csi-translation-lib v0.17.3/go.mod h1:FBya8XvGIqDm2/3evLQNxaFXqv/C2UcZa5JgJt6/qqY=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
-k8s.io/gengo v0.0.0-20190822140433-26a664648505 h1:ZY6yclUKVbZ+SdWnkfY+Je5vrMpKOxmGeKRbsXVmqYM=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.0.0-20180201235237-0fb14efe8c47/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=

--- a/pkg/server/cstorvolumeconfig/backup_endpoint.go
+++ b/pkg/server/cstorvolumeconfig/backup_endpoint.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 
+	version "github.com/hashicorp/go-version"
 	cstorapis "github.com/openebs/api/pkg/apis/cstor/v1"
 	openebsapis "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
 	cstortypes "github.com/openebs/api/pkg/apis/types"
@@ -30,7 +31,6 @@ import (
 	"github.com/openebs/api/pkg/util"
 	snapshot "github.com/openebs/cstor-operators/pkg/snapshot"
 	"github.com/pkg/errors"
-	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -51,7 +51,19 @@ type backupAPIOps struct {
 var (
 	// openebsNamespace is the namespace where openebs is deployed
 	openebsNamespace string
+	// minV1SupportedVersion is the minimum version required to perfrom
+	// CRUD operations on v1 cStor backup and restore resources
+	minV1SupportedVersion *version.Version
 )
+
+func init() {
+	var err error
+	// 2.1.0 is minimum version that supports v1 version of cStor and backup
+	minV1SupportedVersion, err = version.NewVersion("2.1.0")
+	if err != nil {
+		klog.Fatalf("failed to parse 2.1.0 version error: %v", err)
+	}
+}
 
 /***************************REST ENDPOINTS**********************************************************************************************
  * curl on CVC service with port 5757 then it will create backup related resources. We can use below example to execute POST, GET and DELETE methods
@@ -94,7 +106,7 @@ func (s *HTTPServer) backupV1alpha1SpecificRequest(resp http.ResponseWriter, req
 
 // Create is http handler which handles backup create request
 func (bOps *backupAPIOps) create() (interface{}, error) {
-	backup := &openebsapis.CStorBackup{}
+	backup := &cstorapis.CStorBackup{}
 
 	err := decodeBody(bOps.req, backup)
 	if err != nil {
@@ -130,32 +142,41 @@ func (bOps *backupAPIOps) create() (interface{}, error) {
 	// find healthy CVR which will helps to create backup CR
 	cvr, err := findHealthyCVR(bOps.clientset, backup.Spec.VolumeName, bOps.namespace)
 	if err != nil {
-		return nil, CodedError(400, fmt.Sprintf("Failed to find healthy replica"))
+		return nil, CodedError(400, fmt.Sprintf("Failed to find healthy replica for volume %s", backup.Spec.VolumeName))
 	}
 
+	poolName := cvr.ObjectMeta.Labels[cstortypes.CStorPoolInstanceNameLabelKey]
 	backup.ObjectMeta.Labels = map[string]string{
 		cstortypes.CStorPoolInstanceUIDLabelKey:  cvr.ObjectMeta.Labels[cstortypes.CStorPoolInstanceUIDLabelKey],
-		cstortypes.CStorPoolInstanceNameLabelKey: cvr.ObjectMeta.Labels[cstortypes.CStorPoolInstanceNameLabelKey],
+		cstortypes.CStorPoolInstanceNameLabelKey: poolName,
 		cstortypes.PersistentVolumeLabelKey:      cvr.ObjectMeta.Labels[cstortypes.PersistentVolumeLabelKey],
 		"openebs.io/backup":                      backup.Spec.BackupName,
 	}
 
-	// Find last backup snapshot name
-	lastsnap, err := bOps.getLastBackupSnap(backup)
+	poolVersion, err := getPoolVersion(poolName, bOps.namespace, bOps.clientset)
 	if err != nil {
-		return nil, CodedError(400, fmt.Sprintf("Failed create lastbackup"))
+		return nil, CodedError(400, fmt.Sprintf("failed to get %s pool version error: %v", poolName, err))
 	}
 
-	// Initialize backup status as pending
-	backup.Status = openebsapis.BKPCStorStatusPending
-	backup.Spec.PrevSnapName = lastsnap
+	backupInterface, err := bOps.getBackupInterfaceFromPoolVersion(poolVersion, backup)
+	if err != nil {
+		return nil, CodedError(400, fmt.Sprintf("failed to get backupInterface error: %v", err))
+	}
 
+	lastSnapName, err := backupInterface.getOrCreateLastBackupSnap()
+	if err != nil {
+		return nil, CodedError(400, fmt.Sprintf("Failed get or create lastCompleted backup error: %v", err.Error()))
+	}
+	// Initialize backup status as pending
+	backupInterface.setBackupStatus(string(openebsapis.BKPCStorStatusPending))
+	backupInterface.setLastSnapshotName(lastSnapName)
+
+	// NOTE: For logging we are using v1 backup resource itself
 	klog.Infof("Creating backup %s for volume %q poolName: %v poolUUID:%v", backup.Spec.SnapName,
 		backup.Spec.VolumeName,
 		backup.ObjectMeta.Labels[cstortypes.CStorPoolInstanceNameLabelKey],
 		backup.ObjectMeta.Labels[cstortypes.CStorPoolInstanceUIDLabelKey])
-
-	_, err = bOps.clientset.OpenebsV1alpha1().CStorBackups(backup.Namespace).Create(backup)
+	backupInterface, err = backupInterface.createBackupResource()
 	if err != nil {
 		klog.Errorf("Failed to create backup: error '%s'", err.Error())
 		return nil, CodedError(500, err.Error())
@@ -168,7 +189,7 @@ func (bOps *backupAPIOps) create() (interface{}, error) {
 // get is http handler which handles backup get request
 // It will get the snapshot created by the given backup if backup is done/failed
 func (bOps *backupAPIOps) get() (interface{}, error) {
-	backup := &openebsapis.CStorBackup{}
+	backup := &cstorapis.CStorBackup{}
 
 	err := decodeBody(bOps.req, backup)
 	if err != nil {
@@ -191,15 +212,14 @@ func (bOps *backupAPIOps) get() (interface{}, error) {
 	}
 
 	backup.Name = backup.Spec.SnapName + "-" + backup.Spec.VolumeName
-	backupObj, err := bOps.clientset.OpenebsV1alpha1().
-		CStorBackups(backup.Namespace).
-		Get(backup.Name, metav1.GetOptions{})
+
+	backupInterface, err := bOps.getBackupInterface(backup.Name, backup.Namespace)
 	if err != nil {
-		return nil, CodedError(400, fmt.Sprintf("Failed to fetch backup error:%v", err))
+		return nil, CodedError(400, fmt.Sprintf("failed to get backup interface error: %v", err))
 	}
 
-	if !isBackupCompleted(backupObj) {
-		cspiName := backupObj.Labels[cstortypes.CStorPoolInstanceNameLabelKey]
+	if !backupInterface.isBackupCompleted() {
+		cspiName := backupInterface.getCSPIName()
 		// check if node is running or not
 		backupNodeDown := checkIfPoolManagerNodeDown(bOps.k8sclientset, cspiName, bOps.namespace)
 		// check if cstor-pool-mgmt container is running or not
@@ -207,19 +227,13 @@ func (bOps *backupAPIOps) get() (interface{}, error) {
 
 		if backupNodeDown || backupPodDown {
 			// Backup is stalled, let's find last completed-backup status
-			laststat := findLastBackupStat(bOps.clientset, backupObj)
+			laststat := backupInterface.findLastBackupStat()
 			// Update Backup status according to last completed-backup
-			updateBackupStatus(bOps.clientset, backupObj, laststat)
-
-			// Get updated backup object
-			backupObj, err = bOps.clientset.OpenebsV1alpha1().CStorBackups(backup.Namespace).Get(backup.Name, metav1.GetOptions{})
-			if err != nil {
-				return nil, CodedError(400, fmt.Sprintf("Failed to fetch backup error:%v", err))
-			}
+			backupInterface = backupInterface.updateBackupStatus(laststat)
 		}
 	}
 
-	out, err := json.Marshal(backupObj)
+	out, err := json.Marshal(backupInterface.getBackupObject())
 	if err == nil {
 		_, err = bOps.resp.Write(out)
 		if err != nil {
@@ -260,33 +274,23 @@ func (bOps *backupAPIOps) delete() (interface{}, error) {
 }
 
 // deleteBackup delete the relevant cstorBackup/cstorCompletedBackup resource and cstor snapshot for the given backup
-func (bOps *backupAPIOps) deleteBackup(backup, volname, ns, schedule string) error {
+func (bOps *backupAPIOps) deleteBackup(snapName, volname, ns, schedule string) error {
 	lastCompletedBackup := schedule + "-" + volname
+	cstorBackupName := snapName + "-" + volname
 
-	// Let's get the cstorCompletedBackup resource for the given backup
-	// CStorCompletedBackups resource stores the information about last two completed snapshots
-	lastbkp, err := bOps.clientset.
-		OpenebsV1alpha1().
-		CStorCompletedBackups(ns).
-		Get(lastCompletedBackup, metav1.GetOptions{})
-	if err != nil && !k8serror.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to fetch last-completed-backup=%s resource", lastCompletedBackup)
+	backupInterface, err := bOps.getBackupInterface(cstorBackupName, ns)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get backup interface")
 	}
 
-	// lastbkp stores the last(PrevSnapName) and 2nd last(SnapName) completed snapshot
-	// If given backup is the last backup of scheduled backup (lastbkp.Spec.PrevSnapName == backup) or
-	// completedBackup doesn't have successful backup(len(lastbkp.Spec.PrevSnapName) == 0) then we will delete the lastbkp CR
-	// Deleting this CR make sure that next backup of the schedule will be full backup
-	if lastbkp != nil && (lastbkp.Spec.PrevSnapName == backup || len(lastbkp.Spec.PrevSnapName) == 0) {
-		err := bOps.clientset.OpenebsV1alpha1().CStorCompletedBackups(ns).Delete(lastCompletedBackup, &metav1.DeleteOptions{})
-		if err != nil && !k8serror.IsNotFound(err) {
-			return errors.Wrapf(err, "failed to delete last-completed-backup=%s resource", lastCompletedBackup)
-		}
+	err = backupInterface.deleteCompletedBackup(lastCompletedBackup, ns, snapName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete lastCompletedBackup %s", lastCompletedBackup)
 	}
 
 	snapshot := snapshot.Snapshot{
 		VolumeName:   volname,
-		SnapshotName: backup,
+		SnapshotName: snapName,
 		Namespace:    bOps.namespace,
 		SnapClient:   bOps.snapshotter,
 	}
@@ -296,16 +300,15 @@ func (bOps *backupAPIOps) deleteBackup(backup, volname, ns, schedule string) err
 		return errors.Wrapf(err, "snapshot deletion failed")
 	}
 
-	cstorBackup := backup + "-" + volname
-	err = bOps.clientset.OpenebsV1alpha1().CStorBackups(ns).Delete(cstorBackup, &metav1.DeleteOptions{})
-	if err != nil && !k8serror.IsNotFound(err) {
-		return errors.Wrapf(err, "failed to delete cstorbackup: %s resource", cstorBackup)
+	err = backupInterface.deleteBackup(cstorBackupName, ns)
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete cstorbackup: %s resource", cstorBackupName)
 	}
 	return nil
 }
 
 // backupCreateRequestValidations validates the backup create request
-func backupCreateRequestValidations(backup *openebsapis.CStorBackup) error {
+func backupCreateRequestValidations(backup *cstorapis.CStorBackup) error {
 	// backup name is expected
 	if len(strings.TrimSpace(backup.Spec.BackupName)) == 0 {
 		return CodedError(400, fmt.Sprintf("Failed to create backup: missing backup name "))
@@ -342,6 +345,52 @@ func getOpenEBSNamespace() string {
 	return openebsNamespace
 }
 
+func (bOps *backupAPIOps) getBackupInterface(backupName,
+	backupNamespace string) (backupHelper, error) {
+
+	backupObj, err := bOps.clientset.OpenebsV1alpha1().
+		CStorBackups(backupNamespace).
+		Get(backupName, metav1.GetOptions{})
+	if err == nil {
+		backupInterface := newV1Alpha1BackupWrapper(bOps.clientset).setBackup(backupObj)
+		return backupInterface, nil
+	}
+	if k8serror.IsNotFound(err) {
+		backupObj, err := bOps.clientset.CstorV1().
+			CStorBackups(backupNamespace).
+			Get(backupName, metav1.GetOptions{})
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to fetch %s backup v1 version also", backupName)
+		}
+		backupInterface := newV1BackupWrapper(bOps.clientset).setBackup(backupObj)
+		return backupInterface, nil
+	}
+	return nil, errors.Wrapf(err, "failed to fetch %s backup", backupName)
+}
+
+func (bOps *backupAPIOps) getBackupInterfaceFromPoolVersion(
+	poolVersion string, backup *cstorapis.CStorBackup) (backupHelper, error) {
+	// error will be reported when version doesn't contain any valid version pattern
+	// Ex: dev, ci, master
+	currentVersion, err := version.NewVersion(poolVersion)
+	if err != nil {
+		// We need to support backup for ci images also
+		if strings.TrimSpace(poolVersion) != "" && !strings.Contains(poolVersion, "dev") {
+			return nil, errors.Wrapf(err, "failed to parse %q pool version", poolVersion)
+		}
+		klog.Warningf("failed to parse pool %s version error: %v will create v1 version of backup and restore", poolVersion, err)
+	}
+
+	if currentVersion != nil && currentVersion.LessThan(minV1SupportedVersion) {
+		return newV1Alpha1BackupWrapper(bOps.clientset).setBackup(getV1Alpha1BackupFromV1(backup)), nil
+	} else if currentVersion != nil && currentVersion.GreaterThanOrEqual(minV1SupportedVersion) {
+		return newV1BackupWrapper(bOps.clientset).setBackup(backup), nil
+	}
+	// return latest supported version v1
+	// If code reached over here then pool is in non released version i.e dev/ci
+	return newV1BackupWrapper(bOps.clientset).setBackup(backup), nil
+}
+
 // findHealthyCVR returns Heathy CVR if exists else
 // it will return error
 func findHealthyCVR(
@@ -366,8 +415,23 @@ func findHealthyCVR(
 	return nil, errors.New("unable to find healthy CVR")
 }
 
+func getV1Alpha1BackupFromV1(backup *cstorapis.CStorBackup) *openebsapis.CStorBackup {
+	return &openebsapis.CStorBackup{
+		ObjectMeta: backup.ObjectMeta,
+		Spec: openebsapis.CStorBackupSpec{
+			BackupName:   backup.Spec.BackupName,
+			VolumeName:   backup.Spec.VolumeName,
+			SnapName:     backup.Spec.SnapName,
+			PrevSnapName: backup.Spec.PrevSnapName,
+			BackupDest:   backup.Spec.BackupDest,
+			LocalSnap:    backup.Spec.LocalSnap,
+		},
+		Status: openebsapis.CStorBackupStatus(backup.Status),
+	}
+}
+
 // getLastBackupSnap will fetch the last successful backup's snapshot name
-func (bOps *backupAPIOps) getLastBackupSnap(backup *openebsapis.CStorBackup) (string, error) {
+func (bOps *backupAPIOps) getLastBackupSnap(backup *cstorapis.CStorBackup) (string, error) {
 	lastbkpName := backup.Spec.BackupName + "-" + backup.Spec.VolumeName
 	b, err := bOps.clientset.OpenebsV1alpha1().
 		CStorCompletedBackups(backup.Namespace).
@@ -402,145 +466,10 @@ func (bOps *backupAPIOps) getLastBackupSnap(backup *openebsapis.CStorBackup) (st
 	return b.Spec.PrevSnapName, nil
 }
 
-// checkIfPoolManagerNodeDown will check if CSPI pool manager is in running or not
-func checkIfPoolManagerNodeDown(k8sclient kubernetes.Interface, cspiName, namespace string) bool {
-	var nodeDown = true
-	var pod *corev1.Pod
-	var err error
-
-	// If cspiName is not empty then fetch the CStor pool pod using CSPI name
-	if cspiName == "" {
-		klog.Errorf("failed to find pool manager, empty CSPI is provided")
-		return nodeDown
-	}
-	pod, err = fetchPoolManagerFromCSPI(k8sclient, cspiName, namespace)
+func getPoolVersion(cspiName, cspiNamespace string, clientset clientset.Interface) (string, error) {
+	cspi, err := clientset.CstorV1().CStorPoolInstances(cspiNamespace).Get(cspiName, metav1.GetOptions{})
 	if err != nil {
-		klog.Errorf("Failed to find pool manager for CSPI:%s err:%s", cspiName, err.Error())
-		return nodeDown
+		return "", err
 	}
-
-	if pod.Spec.NodeName == "" {
-		klog.Errorf("node name is empty in pool manager %s", pod.Name)
-		return nodeDown
-	}
-
-	node, err := k8sclient.CoreV1().Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
-	if err != nil {
-		klog.Infof("Failed to fetch node info for CSPI:%s: %v", cspiName, err)
-		return nodeDown
-	}
-	for _, nodestat := range node.Status.Conditions {
-		if nodestat.Type == corev1.NodeReady && nodestat.Status != corev1.ConditionTrue {
-			klog.Infof("Node:%v is not in ready state", node.Name)
-			return nodeDown
-		}
-	}
-	return !nodeDown
-}
-
-// checkIfPoolManagerDown will check if pool pod is running or not
-func checkIfPoolManagerDown(k8sclient kubernetes.Interface, cspiName, namespace string) bool {
-	var podDown = true
-	var pod *corev1.Pod
-	var err error
-
-	// If cspiName is not empty then fetch the CStor pool pod using CSPI name
-	if cspiName == "" {
-		klog.Errorf("failed to find pool manager, empty CSPI is provided")
-		return podDown
-	}
-	pod, err = fetchPoolManagerFromCSPI(k8sclient, cspiName, namespace)
-	if err != nil {
-		klog.Errorf("Failed to find pool manager for CSPI:%s err:%s", cspiName, err.Error())
-		return podDown
-	}
-
-	for _, containerstatus := range pod.Status.ContainerStatuses {
-		if containerstatus.Name == "cstor-pool-mgmt" {
-			return !containerstatus.Ready
-		}
-	}
-
-	return podDown
-}
-
-// findLastBackupStat will find the status of given backup from last completed-backup
-func findLastBackupStat(clientset clientset.Interface, backup *openebsapis.CStorBackup) openebsapis.CStorBackupStatus {
-	lastbkpname := backup.Spec.BackupName + "-" + backup.Spec.VolumeName
-	lastbkp, err := clientset.OpenebsV1alpha1().CStorCompletedBackups(backup.Namespace).Get(lastbkpname, metav1.GetOptions{})
-	if err != nil {
-		// Unable to fetch the last backup, so we will return fail state
-		klog.Errorf("Failed to fetch last completed-backup:%s error:%s", lastbkpname, err.Error())
-		return openebsapis.BKPCStorStatusFailed
-	}
-
-	// lastbkp stores the last(PrevSnapName) and 2nd last(SnapName) completed snapshot
-	// let's check if last backup's snapname/PrevSnapName  matches with current snapshot name
-	if backup.Spec.SnapName == lastbkp.Spec.SnapName || backup.Spec.SnapName == lastbkp.Spec.PrevSnapName {
-		return openebsapis.BKPCStorStatusDone
-	}
-
-	// lastbackup snap/prevsnap doesn't match with bkp snapname
-	return openebsapis.BKPCStorStatusFailed
-}
-
-// updateBackupStatus will update the backup status to given status
-func updateBackupStatus(clientset clientset.Interface, backup *openebsapis.CStorBackup, status openebsapis.CStorBackupStatus) {
-	backup.Status = status
-
-	_, err := clientset.OpenebsV1alpha1().CStorBackups(backup.Namespace).Update(backup)
-	if err != nil {
-		klog.Errorf("Failed to update backup:%s with status:%v", backup.Name, status)
-		return
-	}
-}
-
-// fetchPoolManagerFromCSPI returns pool manager pod for provided CSPI
-func fetchPoolManagerFromCSPI(k8sclientset kubernetes.Interface, cspiName, openebsNs string) (*corev1.Pod, error) {
-	cstorPodLabel := "app=cstor-pool"
-	cspiPoolName := cstortypes.CStorPoolInstanceLabelKey + "=" + cspiName
-	podlistops := metav1.ListOptions{
-		LabelSelector: cstorPodLabel + "," + cspiPoolName,
-	}
-
-	if openebsNs == "" {
-		return nil, errors.Errorf("Failed to fetch operator namespace")
-	}
-
-	podList, err := k8sclientset.CoreV1().Pods(openebsNs).List(podlistops)
-	if err != nil {
-		klog.Errorf("Failed to fetch pod list :%v", err)
-		return nil, err
-	}
-
-	if len(podList.Items) != 1 {
-		return nil, errors.Errorf("expected 1 pool manager but got %d pool managers", len(podList.Items))
-	}
-	return &podList.Items[0], nil
-}
-
-// TODO: Move below functions into API because there kind of getter methods.
-
-// isBackupCompleted returns true if backup execution is completed
-func isBackupCompleted(backup *openebsapis.CStorBackup) bool {
-	if isBackupFailed(backup) || isBackupSucceeded(backup) {
-		return true
-	}
-	return false
-}
-
-// isBackupFailed returns true if backup failed
-func isBackupFailed(backup *openebsapis.CStorBackup) bool {
-	if backup.Status == openebsapis.BKPCStorStatusFailed {
-		return true
-	}
-	return false
-}
-
-// isBackupSucceeded returns true if backup completed successfully
-func isBackupSucceeded(backup *openebsapis.CStorBackup) bool {
-	if backup.Status == openebsapis.BKPCStorStatusDone {
-		return true
-	}
-	return false
+	return cspi.VersionDetails.Status.Current, nil
 }

--- a/pkg/server/cstorvolumeconfig/backup_endpoint.go
+++ b/pkg/server/cstorvolumeconfig/backup_endpoint.go
@@ -51,7 +51,7 @@ type backupAPIOps struct {
 var (
 	// openebsNamespace is the namespace where openebs is deployed
 	openebsNamespace string
-	// minV1SupportedVersion is the minimum version required to perfrom
+	// minV1SupportedVersion is the minimum OpenEBS version required to perfrom
 	// CRUD operations on v1 cStor backup and restore resources
 	minV1SupportedVersion *version.Version
 )
@@ -171,7 +171,7 @@ func (bOps *backupAPIOps) create() (interface{}, error) {
 	backupInterface.setBackupStatus(string(openebsapis.BKPCStorStatusPending))
 	backupInterface.setLastSnapshotName(lastSnapName)
 
-	// NOTE: For logging we are using v1 backup resource itself
+	// NOTE: We are logining by using v1 backup resource irrespective of version
 	klog.Infof("Creating backup %s for volume %q poolName: %v poolUUID:%v", backup.Spec.SnapName,
 		backup.Spec.VolumeName,
 		backup.ObjectMeta.Labels[cstortypes.CStorPoolInstanceNameLabelKey],

--- a/pkg/server/cstorvolumeconfig/backup_endpoint.go
+++ b/pkg/server/cstorvolumeconfig/backup_endpoint.go
@@ -58,10 +58,10 @@ var (
 
 func init() {
 	var err error
-	// 2.1.0 is minimum version that supports v1 version of cStor and backup
-	minV1SupportedVersion, err = version.NewVersion("2.1.0")
+	// 2.2.0 is minimum version that supports v1 version of cStor and backup
+	minV1SupportedVersion, err = version.NewVersion("2.2.0")
 	if err != nil {
-		klog.Fatalf("failed to parse 2.1.0 version error: %v", err)
+		klog.Fatalf("failed to parse 2.2.0 version error: %v", err)
 	}
 }
 

--- a/pkg/server/cstorvolumeconfig/backup_restore_helper.go
+++ b/pkg/server/cstorvolumeconfig/backup_restore_helper.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorvolumeconfig
+
+import (
+	cstortypes "github.com/openebs/api/pkg/apis/types"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+// checkIfPoolManagerNodeDown will check if CSPI pool manager is in running or not
+func checkIfPoolManagerNodeDown(k8sclient kubernetes.Interface, cspiName, namespace string) bool {
+	var nodeDown = true
+	var pod *corev1.Pod
+	var err error
+
+	// If cspiName is not empty then fetch the CStor pool pod using CSPI name
+	if cspiName == "" {
+		klog.Errorf("failed to find pool manager, empty CSPI is provided")
+		return nodeDown
+	}
+	pod, err = getPoolManager(k8sclient, cspiName, namespace)
+	if err != nil {
+		klog.Errorf("Failed to find pool manager for CSPI:%s err:%s", cspiName, err.Error())
+		return nodeDown
+	}
+
+	if pod.Spec.NodeName == "" {
+		klog.Errorf("node name is empty in pool manager %s", pod.Name)
+		return nodeDown
+	}
+
+	node, err := k8sclient.CoreV1().Nodes().Get(pod.Spec.NodeName, metav1.GetOptions{})
+	if err != nil {
+		klog.Infof("Failed to fetch node info for CSPI:%s: %v", cspiName, err)
+		return nodeDown
+	}
+	for _, nodestat := range node.Status.Conditions {
+		if nodestat.Type == corev1.NodeReady && nodestat.Status != corev1.ConditionTrue {
+			klog.Infof("Node:%v is not in ready state", node.Name)
+			return nodeDown
+		}
+	}
+	return !nodeDown
+}
+
+// checkIfPoolManagerDown will check if pool pod is running or not
+func checkIfPoolManagerDown(k8sclient kubernetes.Interface, cspiName, namespace string) bool {
+	var podDown = true
+	var pod *corev1.Pod
+	var err error
+
+	// If cspiName is not empty then fetch the CStor pool pod using CSPI name
+	if cspiName == "" {
+		klog.Errorf("failed to find pool manager, empty CSPI is provided")
+		return podDown
+	}
+	pod, err = getPoolManager(k8sclient, cspiName, namespace)
+	if err != nil {
+		klog.Errorf("Failed to find pool manager for CSPI:%s err:%s", cspiName, err.Error())
+		return podDown
+	}
+
+	for _, containerstatus := range pod.Status.ContainerStatuses {
+		if containerstatus.Name == "cstor-pool-mgmt" {
+			return !containerstatus.Ready
+		}
+	}
+
+	return podDown
+}
+
+// getPoolManager returns pool manager pod for provided CSPI
+func getPoolManager(k8sclientset kubernetes.Interface, cspiName, openebsNs string) (*corev1.Pod, error) {
+	cstorPodLabel := "app=cstor-pool"
+	cspiPoolName := cstortypes.CStorPoolInstanceLabelKey + "=" + cspiName
+	podlistops := metav1.ListOptions{
+		LabelSelector: cstorPodLabel + "," + cspiPoolName,
+	}
+
+	if openebsNs == "" {
+		return nil, errors.Errorf("Failed to fetch operator namespace")
+	}
+
+	podList, err := k8sclientset.CoreV1().Pods(openebsNs).List(podlistops)
+	if err != nil {
+		klog.Errorf("Failed to fetch pod list :%v", err)
+		return nil, err
+	}
+
+	if len(podList.Items) != 1 {
+		return nil, errors.Errorf("expected 1 pool manager but got %d pool managers", len(podList.Items))
+	}
+	return &podList.Items[0], nil
+}

--- a/pkg/server/cstorvolumeconfig/https_test.go
+++ b/pkg/server/cstorvolumeconfig/https_test.go
@@ -834,7 +834,7 @@ func TestBackupDeleteEndPoint(t *testing.T) {
 		},
 		"When delete method is triggered on v1 backup endpoint without any error injection": {
 			cspcName:    "cspc-cstor-pool5",
-			poolVersion: "2.1.0",
+			poolVersion: "2.2.0",
 			// Since json tags are same for v1 and v1alpha version there won't be any problem
 			cstorBackup: &openebsapis.CStorBackup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1185,7 +1185,7 @@ func TestRestoreEndPoint(t *testing.T) {
 		},
 		"When restore is triggered for pools on v1 version": {
 			cspcName:    "cspc-cstor-pool7",
-			poolVersion: "2.1.0",
+			poolVersion: "2.2.0",
 			cstorRestore: &openebsapis.CStorRestore{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: namespace,

--- a/pkg/server/cstorvolumeconfig/interface.go
+++ b/pkg/server/cstorvolumeconfig/interface.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorvolumeconfig
+
+// backupHelper is an interface which will serve
+// the request of different versions of backup resources
+type backupHelper interface {
+	isBackupCompleted() bool
+	getCSPIName() string
+	findLastBackupStat() string
+	updateBackupStatus(string) backupHelper
+	getBackupObject() interface{}
+	//TODO: Rename the function
+	deleteCompletedBackup(name, namespace, snapName string) error
+	deleteBackup(name, namespace string) error
+	getOrCreateLastBackupSnap() (string, error)
+	setBackupStatus(string) backupHelper
+	setLastSnapshotName(string) backupHelper
+	createBackupResource() (backupHelper, error)
+}

--- a/pkg/server/cstorvolumeconfig/v1_backup.go
+++ b/pkg/server/cstorvolumeconfig/v1_backup.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorvolumeconfig
+
+import (
+	cstorapis "github.com/openebs/api/pkg/apis/cstor/v1"
+	cstortypes "github.com/openebs/api/pkg/apis/types"
+	clientset "github.com/openebs/api/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+type v1BackupWrapper struct {
+	backup    *cstorapis.CStorBackup
+	clientset clientset.Interface
+}
+
+func newV1BackupWrapper(clientset clientset.Interface) *v1BackupWrapper {
+	return &v1BackupWrapper{
+		clientset: clientset}
+}
+
+// setBackup sets the v1alpha1 backup in backupWrapper
+func (backupWrapper *v1BackupWrapper) setBackup(
+	backup *cstorapis.CStorBackup) *v1BackupWrapper {
+	backupWrapper.backup = backup
+	return backupWrapper
+}
+
+// isBackupCompleted returns true if backup execution is completed
+func (backupWrapper *v1BackupWrapper) isBackupCompleted() bool {
+	if backupWrapper.backup.IsBackupFailed() ||
+		backupWrapper.backup.IsBackupSucceeded() {
+		return true
+	}
+	return false
+}
+
+func (backupWrapper *v1BackupWrapper) getCSPIName() string {
+	return backupWrapper.backup.GetLabels()[cstortypes.CStorPoolInstanceNameLabelKey]
+}
+
+func (backupWrapper *v1BackupWrapper) findLastBackupStat() string {
+	lastbkpname := backupWrapper.backup.Spec.BackupName + "-" + backupWrapper.backup.Spec.VolumeName
+	lastbkp, err := backupWrapper.clientset.CstorV1().
+		CStorCompletedBackups(backupWrapper.backup.Namespace).
+		Get(lastbkpname, metav1.GetOptions{})
+	if err != nil {
+		// Unable to fetch the last backup, so we will return fail state
+		klog.Errorf("Failed to fetch last completed-backup:%s error:%s", lastbkpname, err.Error())
+		return string(cstorapis.BKPCStorStatusFailed)
+	}
+
+	// lastbkp stores the lastSnap and 2nd last(SeconfLastSnapName) completed snapshot
+	// let's check if last backup's snapname/PrevSnapName  matches with current snapshot name
+	if backupWrapper.backup.Spec.SnapName == lastbkp.Spec.LastSnapName ||
+		backupWrapper.backup.Spec.SnapName == lastbkp.Spec.SecondLastSnapName {
+		return string(cstorapis.BKPCStorStatusDone)
+	}
+
+	// lastbackup last snap/second last snap doesn't match with backup snapname
+	return string(cstorapis.BKPCStorStatusFailed)
+}
+
+func (backupWrapper *v1BackupWrapper) updateBackupStatus(
+	backupStatus string) backupHelper {
+	backupWrapper.backup.Status = cstorapis.CStorBackupStatus(backupStatus)
+
+	_, err := backupWrapper.clientset.
+		CstorV1().
+		CStorBackups(backupWrapper.backup.Namespace).Update(backupWrapper.backup)
+	if err != nil {
+		klog.Errorf("Failed to update backup:%s with status:%v", backupWrapper.backup.Name, backupStatus)
+	}
+	return backupWrapper
+}
+
+func (backupWrapper *v1BackupWrapper) deleteCompletedBackup(name, namespace, snapName string) error {
+	// Let's get the cstorCompletedBackup resource for the given backup
+	// CStorCompletedBackups resource stores the information about last two completed snapshots
+	lastbkp, err := backupWrapper.clientset.
+		CstorV1().
+		CStorCompletedBackups(namespace).
+		Get(name, metav1.GetOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to fetch last-completed-backup=%s resource", name)
+	}
+
+	// lastbkp stores the last(LastSnapName) and 2nd last(SecondLastSnapName) completed snapshot
+	// If given backup is the last backup of scheduled backup (lastbkp.Spec.PrevSnapName == backup) or
+	// completedBackup doesn't have successful backup(len(lastbkp.Spec.PrevSnapName) == 0) then we will delete the lastbkp CR
+	// Deleting this CR make sure that next backup of the schedule will be full backup
+	if lastbkp != nil && (lastbkp.Spec.LastSnapName == snapName || len(lastbkp.Spec.LastSnapName) == 0) {
+		err := backupWrapper.clientset.CstorV1().CStorCompletedBackups(namespace).Delete(name, &metav1.DeleteOptions{})
+		if err != nil && !k8serror.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to delete last-completed-backup=%s resource", name)
+		}
+	}
+	return nil
+}
+
+func (backupWrapper *v1BackupWrapper) deleteBackup(name, namespace string) error {
+	err := backupWrapper.clientset.CstorV1().CStorBackups(namespace).Delete(name, &metav1.DeleteOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to delete cstorbackup: %s resource", name)
+	}
+	return nil
+}
+
+func (backupWrapper *v1BackupWrapper) getOrCreateLastBackupSnap() (string, error) {
+	lastbkpName := backupWrapper.backup.Spec.BackupName + "-" + backupWrapper.backup.Spec.VolumeName
+
+	completedBackup, err := backupWrapper.clientset.CstorV1().
+		CStorCompletedBackups(backupWrapper.backup.Namespace).
+		Get(lastbkpName, metav1.GetOptions{})
+	if err != nil {
+		if k8serror.IsNotFound(err) {
+			// Build CStorCompletedBackup which will be helpful for incremental backups
+			bk := &cstorapis.CStorCompletedBackup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      lastbkpName,
+					Namespace: backupWrapper.backup.Namespace,
+					Labels:    backupWrapper.backup.Labels,
+				},
+				Spec: cstorapis.CStorCompletedBackupSpec{
+					BackupName: backupWrapper.backup.Spec.BackupName,
+					VolumeName: backupWrapper.backup.Spec.VolumeName,
+				},
+			}
+
+			_, err := backupWrapper.clientset.CstorV1().CStorCompletedBackups(bk.Namespace).Create(bk)
+			if err != nil {
+				klog.Errorf("Error creating v1 version of last completed-backup resource for backup:%v err:%v", bk.Spec.BackupName, err)
+				return "", err
+			}
+			klog.Infof("LastBackup resource created for backup:%s volume:%s", bk.Spec.BackupName, bk.Spec.VolumeName)
+			return "", nil
+		}
+		return "", errors.Errorf("failed to get lastbkpName %s error: %s", lastbkpName, err.Error())
+	}
+
+	// LastSnapName stores the last completed backup snapshot
+	return completedBackup.Spec.LastSnapName, nil
+}
+
+func (backupWrapper *v1BackupWrapper) getBackupObject() interface{} {
+	return backupWrapper.backup
+}
+
+func (backupWrapper *v1BackupWrapper) setBackupStatus(status string) backupHelper {
+	backupWrapper.backup.Status = cstorapis.CStorBackupStatus(status)
+	return backupWrapper
+}
+
+func (backupWrapper *v1BackupWrapper) setLastSnapshotName(snapName string) backupHelper {
+	backupWrapper.backup.Spec.PrevSnapName = snapName
+	return backupWrapper
+}
+
+func (backupWrapper *v1BackupWrapper) createBackupResource() (backupHelper, error) {
+	_, err := backupWrapper.clientset.CstorV1().
+		CStorBackups(backupWrapper.backup.Namespace).
+		Create(backupWrapper.backup)
+	if err != nil {
+		klog.Errorf("Failed to create backup: error '%s'", err.Error())
+		return nil, errors.Wrapf(err, "failed to create backup %s", backupWrapper.backup.Name)
+	}
+	return backupWrapper, nil
+}

--- a/pkg/server/cstorvolumeconfig/v1_backup.go
+++ b/pkg/server/cstorvolumeconfig/v1_backup.go
@@ -45,8 +45,8 @@ func (backupWrapper *v1BackupWrapper) setBackup(
 
 // isBackupCompleted returns true if backup execution is completed
 func (backupWrapper *v1BackupWrapper) isBackupCompleted() bool {
-	if backupWrapper.backup.IsBackupFailed() ||
-		backupWrapper.backup.IsBackupSucceeded() {
+	if backupWrapper.backup.IsFailed() ||
+		backupWrapper.backup.IsSucceeded() {
 		return true
 	}
 	return false

--- a/pkg/server/cstorvolumeconfig/v1_backup.go
+++ b/pkg/server/cstorvolumeconfig/v1_backup.go
@@ -126,7 +126,16 @@ func (backupWrapper *v1BackupWrapper) deleteBackup(name, namespace string) error
 func (backupWrapper *v1BackupWrapper) getOrCreateLastBackupSnap() (string, error) {
 	lastbkpName := backupWrapper.backup.Spec.BackupName + "-" + backupWrapper.backup.Spec.VolumeName
 
-	completedBackup, err := backupWrapper.clientset.CstorV1().
+	// NOTE: When only few pools of CStorPoolCluster is upgrade and if the backup request is scheduled
+	// backup then we need to check for v1alpha1 version of completed backup to get last snapshot name
+	completedBackup, err := backupWrapper.clientset.OpenebsV1alpha1().
+		CStorCompletedBackups(backupWrapper.backup.Namespace).
+		Get(lastbkpName, metav1.GetOptions{})
+	if err == nil {
+		return completedBackup.Spec.PrevSnapName, nil
+	}
+
+	completedBackup, err = backupWrapper.clientset.CstorV1().
 		CStorCompletedBackups(backupWrapper.backup.Namespace).
 		Get(lastbkpName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/server/cstorvolumeconfig/v1alpha1_backup.go
+++ b/pkg/server/cstorvolumeconfig/v1alpha1_backup.go
@@ -132,11 +132,14 @@ func (backupWrapper *v1Alpha1BackupWrapper) getBackupObject() interface{} {
 func (backupWrapper *v1Alpha1BackupWrapper) getOrCreateLastBackupSnap() (string, error) {
 	lastbkpName := backupWrapper.backup.Spec.BackupName + "-" + backupWrapper.backup.Spec.VolumeName
 
-	// NOTE: When only few pools of CStorPoolCluster is upgrade and if the backup request is scheduled
+	// When only few pools of CStorPoolCluster is upgrade and if the backup request is scheduled
 	// backup then we need to check for v1 version of completed backup to get last snapshot name
 	completedBackup, err := backupWrapper.clientset.CstorV1().
 		CStorCompletedBackups(backupWrapper.backup.Namespace).
 		Get(lastbkpName, metav1.GetOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		return "", errors.Wrapf(err, "failed to get v1 completed backup %s", lastbkpName)
+	}
 	if err == nil {
 		return completedBackup.Spec.LastSnapName, nil
 	}

--- a/pkg/server/cstorvolumeconfig/v1alpha1_backup.go
+++ b/pkg/server/cstorvolumeconfig/v1alpha1_backup.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cstorvolumeconfig
+
+import (
+	openebsapis "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
+	cstortypes "github.com/openebs/api/pkg/apis/types"
+	clientset "github.com/openebs/api/pkg/client/clientset/versioned"
+	"github.com/pkg/errors"
+	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+// v1Alpha1BackupWrapper holds the information
+// about v1alpha1 backup resource
+type v1Alpha1BackupWrapper struct {
+	backup    *openebsapis.CStorBackup
+	clientset clientset.Interface
+}
+
+func newV1Alpha1BackupWrapper(clientset clientset.Interface) *v1Alpha1BackupWrapper {
+	return &v1Alpha1BackupWrapper{
+		clientset: clientset}
+}
+
+// setBackup sets the v1alpha1 backup in backupWrapper
+func (backupWrapper *v1Alpha1BackupWrapper) setBackup(
+	backup *openebsapis.CStorBackup) *v1Alpha1BackupWrapper {
+	backupWrapper.backup = backup
+	return backupWrapper
+}
+
+// isBackupCompleted returns true if backup execution is completed
+func (backupWrapper *v1Alpha1BackupWrapper) isBackupCompleted() bool {
+	if isBackupFailed(backupWrapper.backup) ||
+		isBackupSucceeded(backupWrapper.backup) {
+		return true
+	}
+	return false
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) getCSPIName() string {
+	return backupWrapper.backup.GetLabels()[cstortypes.CStorPoolInstanceNameLabelKey]
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) findLastBackupStat() string {
+	lastbkpname := backupWrapper.backup.Spec.BackupName + "-" + backupWrapper.backup.Spec.VolumeName
+	lastbkp, err := backupWrapper.clientset.OpenebsV1alpha1().
+		CStorCompletedBackups(backupWrapper.backup.Namespace).
+		Get(lastbkpname, metav1.GetOptions{})
+	if err != nil {
+		// Unable to fetch the last backup, so we will return fail state
+		klog.Errorf("Failed to fetch last completed-backup:%s error:%s", lastbkpname, err.Error())
+		return string(openebsapis.BKPCStorStatusFailed)
+	}
+
+	// lastbkp stores the last(PrevSnapName) and 2nd last(SnapName) completed snapshot
+	// let's check if last backup's snapname/PrevSnapName  matches with current snapshot name
+	if backupWrapper.backup.Spec.SnapName == lastbkp.Spec.SnapName ||
+		backupWrapper.backup.Spec.SnapName == lastbkp.Spec.PrevSnapName {
+		return string(openebsapis.BKPCStorStatusDone)
+	}
+
+	// lastbackup snap/prevsnap doesn't match with bkp snapname
+	return string(openebsapis.BKPCStorStatusFailed)
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) updateBackupStatus(
+	backupStatus string) backupHelper {
+	backupWrapper.backup.Status = openebsapis.CStorBackupStatus(backupStatus)
+
+	_, err := backupWrapper.clientset.
+		OpenebsV1alpha1().
+		CStorBackups(backupWrapper.backup.Namespace).Update(backupWrapper.backup)
+	if err != nil {
+		klog.Errorf("Failed to update backup:%s with status:%v", backupWrapper.backup.Name, backupStatus)
+	}
+	return backupWrapper
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) deleteCompletedBackup(name, namespace, snapName string) error {
+	// Let's get the cstorCompletedBackup resource for the given backup
+	// CStorCompletedBackups resource stores the information about last two completed snapshots
+	lastbkp, err := backupWrapper.clientset.
+		OpenebsV1alpha1().
+		CStorCompletedBackups(namespace).
+		Get(name, metav1.GetOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to fetch last-completed-backup=%s resource", name)
+	}
+
+	// lastbkp stores the last(PrevSnapName) and 2nd last(SnapName) completed snapshot
+	// If given backup is the last backup of scheduled backup (lastbkp.Spec.PrevSnapName == backup) or
+	// completedBackup doesn't have successful backup(len(lastbkp.Spec.PrevSnapName) == 0) then we will delete the lastbkp CR
+	// Deleting this CR make sure that next backup of the schedule will be full backup
+	if lastbkp != nil && (lastbkp.Spec.PrevSnapName == snapName || len(lastbkp.Spec.PrevSnapName) == 0) {
+		err := backupWrapper.clientset.OpenebsV1alpha1().CStorCompletedBackups(namespace).Delete(name, &metav1.DeleteOptions{})
+		if err != nil && !k8serror.IsNotFound(err) {
+			return errors.Wrapf(err, "failed to delete last-completed-backup=%s resource", name)
+		}
+	}
+	return nil
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) deleteBackup(name, namespace string) error {
+	err := backupWrapper.clientset.OpenebsV1alpha1().CStorBackups(namespace).Delete(name, &metav1.DeleteOptions{})
+	if err != nil && !k8serror.IsNotFound(err) {
+		return errors.Wrapf(err, "failed to delete cstorbackup: %s resource", name)
+	}
+	return nil
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) getBackupObject() interface{} {
+	return backupWrapper.backup
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) getOrCreateLastBackupSnap() (string, error) {
+	lastbkpName := backupWrapper.backup.Spec.BackupName + "-" + backupWrapper.backup.Spec.VolumeName
+
+	b, err := backupWrapper.clientset.OpenebsV1alpha1().
+		CStorCompletedBackups(backupWrapper.backup.Namespace).
+		Get(lastbkpName, metav1.GetOptions{})
+	if err != nil {
+		if k8serror.IsNotFound(err) {
+			// Build CStorCompletedBackup which will helpful for incremental backups
+			bk := &openebsapis.CStorCompletedBackup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      lastbkpName,
+					Namespace: backupWrapper.backup.Namespace,
+					Labels:    backupWrapper.backup.Labels,
+				},
+				Spec: openebsapis.CStorBackupSpec{
+					BackupName: backupWrapper.backup.Spec.BackupName,
+					VolumeName: backupWrapper.backup.Spec.VolumeName,
+				},
+			}
+
+			_, err := backupWrapper.clientset.OpenebsV1alpha1().CStorCompletedBackups(bk.Namespace).Create(bk)
+			if err != nil {
+				klog.Errorf("Error creating last completed-backup resource for backup:%v err:%v", bk.Spec.BackupName, err)
+				return "", err
+			}
+			klog.Infof("LastBackup resource created for backup:%s volume:%s", bk.Spec.BackupName, bk.Spec.VolumeName)
+			return "", nil
+		}
+		return "", errors.Errorf("failed to get lastbkpName %s error: %s", lastbkpName, err.Error())
+	}
+
+	// PrevSnapName stores the last completed backup snapshot
+	return b.Spec.PrevSnapName, nil
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) setBackupStatus(status string) backupHelper {
+	backupWrapper.backup.Status = openebsapis.CStorBackupStatus(status)
+	return backupWrapper
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) setLastSnapshotName(snapName string) backupHelper {
+	backupWrapper.backup.Spec.PrevSnapName = snapName
+	return backupWrapper
+}
+
+func (backupWrapper *v1Alpha1BackupWrapper) createBackupResource() (backupHelper, error) {
+	_, err := backupWrapper.clientset.OpenebsV1alpha1().
+		CStorBackups(backupWrapper.backup.Namespace).
+		Create(backupWrapper.backup)
+	if err != nil {
+		klog.Errorf("Failed to create backup: error '%s'", err.Error())
+		return backupWrapper, errors.Wrapf(err, "failed to create backup %s", backupWrapper.backup.Name)
+	}
+	return backupWrapper, nil
+}
+
+// isBackupFailed returns true if backup failed
+func isBackupFailed(backup *openebsapis.CStorBackup) bool {
+	if backup.Status == openebsapis.BKPCStorStatusFailed {
+		return true
+	}
+	return false
+}
+
+// isBackupSucceeded returns true if backup completed successfully
+func isBackupSucceeded(backup *openebsapis.CStorBackup) bool {
+	if backup.Status == openebsapis.BKPCStorStatusDone {
+		return true
+	}
+	return false
+}

--- a/pkg/server/cstorvolumeconfig/v1alpha1_restore.go
+++ b/pkg/server/cstorvolumeconfig/v1alpha1_restore.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cstorvolumeconfig
+
+import (
+	openebsapis "github.com/openebs/api/pkg/apis/openebs.io/v1alpha1"
+	cstortypes "github.com/openebs/api/pkg/apis/types"
+	"k8s.io/klog"
+)
+
+func (rOps *restoreAPIOps) getV1Alpha1CStorRestoreStatus(
+	restoreList *openebsapis.CStorRestoreList) openebsapis.CStorRestoreStatus {
+	rstStatus := openebsapis.RSTCStorStatusEmpty
+	namespace := getOpenEBSNamespace()
+
+	for _, restore := range restoreList.Items {
+		rstStatus = restore.Status
+		if restore.Status != openebsapis.RSTCStorStatusDone &&
+			restore.Status != openebsapis.RSTCStorStatusFailed {
+			poolName := restore.Labels[cstortypes.CStorPoolInstanceLabelKey]
+			isPoolDown := isPoolManagerDown(rOps.k8sclientset, poolName, namespace)
+			if isPoolDown {
+				rstStatus = openebsapis.RSTCStorStatusFailed
+			}
+		}
+
+		switch rstStatus {
+		case openebsapis.RSTCStorStatusInProgress:
+			rstStatus = openebsapis.RSTCStorStatusInProgress
+		case openebsapis.RSTCStorStatusFailed, openebsapis.RSTCStorStatusInvalid:
+			if restore.Status != rstStatus {
+				// Restore for given CVR may failed due to node failure or pool failure
+				// Let's update status for given CVR's restore to failed
+				restore.Status = rstStatus
+				_, err := rOps.clientset.OpenebsV1alpha1().CStorRestores(restore.Namespace).Update(&restore)
+				if err != nil {
+					klog.Errorf("Failed to update restore:%s with status:%v", restore.Name, rstStatus)
+				}
+				rstStatus = openebsapis.RSTCStorStatusFailed
+			}
+		case openebsapis.RSTCStorStatusDone:
+			if rstStatus != openebsapis.RSTCStorStatusFailed {
+				rstStatus = openebsapis.RSTCStorStatusDone
+			}
+		}
+
+		klog.Infof("Restore:%v status is %v", restore.Name, restore.Status)
+
+		if rstStatus == openebsapis.RSTCStorStatusInProgress {
+			break
+		}
+	}
+	return rstStatus
+}

--- a/vendor/github.com/hashicorp/go-version/LICENSE
+++ b/vendor/github.com/hashicorp/go-version/LICENSE
@@ -1,0 +1,354 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. “Contributor”
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. “Contributor Version”
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor’s Contribution.
+
+1.3. “Contribution”
+
+     means Covered Software of a particular Contributor.
+
+1.4. “Covered Software”
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. “Incompatible With Secondary Licenses”
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of version
+        1.1 or earlier of the License, but not also under the terms of a
+        Secondary License.
+
+1.6. “Executable Form”
+
+     means any form of the work other than Source Code Form.
+
+1.7. “Larger Work”
+
+     means a work that combines Covered Software with other material, in a separate
+     file or files, that is not Covered Software.
+
+1.8. “License”
+
+     means this document.
+
+1.9. “Licensable”
+
+     means having the right to grant, to the maximum extent possible, whether at the
+     time of the initial grant or subsequently, any and all of the rights conveyed by
+     this License.
+
+1.10. “Modifications”
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to, deletion
+        from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. “Patent Claims” of a Contributor
+
+      means any patent claim(s), including without limitation, method, process,
+      and apparatus claims, in any patent Licensable by such Contributor that
+      would be infringed, but for the grant of the License, by the making,
+      using, selling, offering for sale, having made, import, or transfer of
+      either its Contributions or its Contributor Version.
+
+1.12. “Secondary License”
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. “Source Code Form”
+
+      means the form of the work preferred for making modifications.
+
+1.14. “You” (or “Your”)
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, “You” includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, “control” means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or as
+        part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its Contributions
+        or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution become
+     effective for each Contribution on the date the Contributor first distributes
+     such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under this
+     License. No additional rights or licenses will be implied from the distribution
+     or licensing of Covered Software under this License. Notwithstanding Section
+     2.1(b) above, no patent license is granted by a Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party’s
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of its
+        Contributions.
+
+     This License does not grant any rights in the trademarks, service marks, or
+     logos of any Contributor (except as may be necessary to comply with the
+     notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this License
+     (see Section 10.2) or under the terms of a Secondary License (if permitted
+     under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its Contributions
+     are its original creation(s) or it has sufficient rights to grant the
+     rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under applicable
+     copyright doctrines of fair use, fair dealing, or other equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under the
+     terms of this License. You must inform recipients that the Source Code Form
+     of the Covered Software is governed by the terms of this License, and how
+     they can obtain a copy of this License. You may not attempt to alter or
+     restrict the recipients’ rights in the Source Code Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this License,
+        or sublicense it under different terms, provided that the license for
+        the Executable Form does not attempt to limit or alter the recipients’
+        rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for the
+     Covered Software. If the Larger Work is a combination of Covered Software
+     with a work governed by one or more Secondary Licenses, and the Covered
+     Software is not Incompatible With Secondary Licenses, this License permits
+     You to additionally distribute such Covered Software under the terms of
+     such Secondary License(s), so that the recipient of the Larger Work may, at
+     their option, further distribute the Covered Software under the terms of
+     either this License or such Secondary License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices (including
+     copyright notices, patent notices, disclaimers of warranty, or limitations
+     of liability) contained within the Source Code Form of the Covered
+     Software, except that You may alter any license notices to the extent
+     required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on behalf
+     of any Contributor. You must make it absolutely clear that any such
+     warranty, support, indemnity, or liability obligation is offered by You
+     alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute, judicial
+   order, or regulation then You must: (a) comply with the terms of this License
+   to the maximum extent possible; and (b) describe the limitations and the code
+   they affect. Such description must be placed in a text file included with all
+   distributions of the Covered Software under this License. Except to the
+   extent prohibited by statute or regulation, such description must be
+   sufficiently detailed for a recipient of ordinary skill to be able to
+   understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing basis,
+     if such Contributor fails to notify You of the non-compliance by some
+     reasonable means prior to 60 days after You have come back into compliance.
+     Moreover, Your grants from a particular Contributor are reinstated on an
+     ongoing basis if such Contributor notifies You of the non-compliance by
+     some reasonable means, this is the first time You have received notice of
+     non-compliance with this License from such Contributor, and You become
+     compliant prior to 30 days after Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions, counter-claims,
+     and cross-claims) alleging that a Contributor Version directly or
+     indirectly infringes any patent, then the rights granted to You by any and
+     all Contributors for the Covered Software under Section 2.1 of this License
+     shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an “as is” basis, without
+   warranty of any kind, either expressed, implied, or statutory, including,
+   without limitation, warranties that the Covered Software is free of defects,
+   merchantable, fit for a particular purpose or non-infringing. The entire
+   risk as to the quality and performance of the Covered Software is with You.
+   Should any Covered Software prove defective in any respect, You (not any
+   Contributor) assume the cost of any necessary servicing, repair, or
+   correction. This disclaimer of warranty constitutes an essential part of this
+   License. No use of  any Covered Software is authorized under this License
+   except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from such
+   party’s negligence to the extent applicable law prohibits such limitation.
+   Some jurisdictions do not allow the exclusion or limitation of incidental or
+   consequential damages, so this exclusion and limitation may not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts of
+   a jurisdiction where the defendant maintains its principal place of business
+   and such litigation shall be governed by laws of that jurisdiction, without
+   reference to its conflict-of-law provisions. Nothing in this Section shall
+   prevent a party’s ability to bring cross-claims or counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject matter
+   hereof. If any provision of this License is held to be unenforceable, such
+   provision shall be reformed only to the extent necessary to make it
+   enforceable. Any law or regulation which provides that the language of a
+   contract shall be construed against the drafter shall not be used to construe
+   this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version of
+      the License under which You originally received the Covered Software, or
+      under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a modified
+      version of this License if you rename the license and remove any
+      references to the name of the license steward (except to note that such
+      modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary Licenses
+      If You choose to distribute Source Code Form that is Incompatible With
+      Secondary Licenses under the terms of this version of the License, the
+      notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file, then
+You may include the notice in a location (such as a LICENSE file in a relevant
+directory) where a recipient would be likely to look for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - “Incompatible With Secondary Licenses” Notice
+
+      This Source Code Form is “Incompatible
+      With Secondary Licenses”, as defined by
+      the Mozilla Public License, v. 2.0.
+

--- a/vendor/github.com/hashicorp/go-version/README.md
+++ b/vendor/github.com/hashicorp/go-version/README.md
@@ -1,0 +1,66 @@
+# Versioning Library for Go
+[![Build Status](https://circleci.com/gh/hashicorp/go-version/tree/master.svg?style=svg)](https://circleci.com/gh/hashicorp/go-version/tree/master)
+[![GoDoc](https://godoc.org/github.com/hashicorp/go-version?status.svg)](https://godoc.org/github.com/hashicorp/go-version)
+
+go-version is a library for parsing versions and version constraints,
+and verifying versions against a set of constraints. go-version
+can sort a collection of versions properly, handles prerelease/beta
+versions, can increment versions, etc.
+
+Versions used with go-version must follow [SemVer](http://semver.org/).
+
+## Installation and Usage
+
+Package documentation can be found on
+[GoDoc](http://godoc.org/github.com/hashicorp/go-version).
+
+Installation can be done with a normal `go get`:
+
+```
+$ go get github.com/hashicorp/go-version
+```
+
+#### Version Parsing and Comparison
+
+```go
+v1, err := version.NewVersion("1.2")
+v2, err := version.NewVersion("1.5+metadata")
+
+// Comparison example. There is also GreaterThan, Equal, and just
+// a simple Compare that returns an int allowing easy >=, <=, etc.
+if v1.LessThan(v2) {
+    fmt.Printf("%s is less than %s", v1, v2)
+}
+```
+
+#### Version Constraints
+
+```go
+v1, err := version.NewVersion("1.2")
+
+// Constraints example.
+constraints, err := version.NewConstraint(">= 1.0, < 1.4")
+if constraints.Check(v1) {
+	fmt.Printf("%s satisfies constraints %s", v1, constraints)
+}
+```
+
+#### Version Sorting
+
+```go
+versionsRaw := []string{"1.1", "0.7.1", "1.4-beta", "1.4", "2"}
+versions := make([]*version.Version, len(versionsRaw))
+for i, raw := range versionsRaw {
+    v, _ := version.NewVersion(raw)
+    versions[i] = v
+}
+
+// After this, the versions are properly sorted
+sort.Sort(version.Collection(versions))
+```
+
+## Issues and Contributing
+
+If you find an issue with this library, please report an issue. If you'd
+like, we welcome any contributions. Fork this library and submit a pull
+request.

--- a/vendor/github.com/hashicorp/go-version/constraint.go
+++ b/vendor/github.com/hashicorp/go-version/constraint.go
@@ -1,0 +1,204 @@
+package version
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+)
+
+// Constraint represents a single constraint for a version, such as
+// ">= 1.0".
+type Constraint struct {
+	f        constraintFunc
+	check    *Version
+	original string
+}
+
+// Constraints is a slice of constraints. We make a custom type so that
+// we can add methods to it.
+type Constraints []*Constraint
+
+type constraintFunc func(v, c *Version) bool
+
+var constraintOperators map[string]constraintFunc
+
+var constraintRegexp *regexp.Regexp
+
+func init() {
+	constraintOperators = map[string]constraintFunc{
+		"":   constraintEqual,
+		"=":  constraintEqual,
+		"!=": constraintNotEqual,
+		">":  constraintGreaterThan,
+		"<":  constraintLessThan,
+		">=": constraintGreaterThanEqual,
+		"<=": constraintLessThanEqual,
+		"~>": constraintPessimistic,
+	}
+
+	ops := make([]string, 0, len(constraintOperators))
+	for k := range constraintOperators {
+		ops = append(ops, regexp.QuoteMeta(k))
+	}
+
+	constraintRegexp = regexp.MustCompile(fmt.Sprintf(
+		`^\s*(%s)\s*(%s)\s*$`,
+		strings.Join(ops, "|"),
+		VersionRegexpRaw))
+}
+
+// NewConstraint will parse one or more constraints from the given
+// constraint string. The string must be a comma-separated list of
+// constraints.
+func NewConstraint(v string) (Constraints, error) {
+	vs := strings.Split(v, ",")
+	result := make([]*Constraint, len(vs))
+	for i, single := range vs {
+		c, err := parseSingle(single)
+		if err != nil {
+			return nil, err
+		}
+
+		result[i] = c
+	}
+
+	return Constraints(result), nil
+}
+
+// Check tests if a version satisfies all the constraints.
+func (cs Constraints) Check(v *Version) bool {
+	for _, c := range cs {
+		if !c.Check(v) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Returns the string format of the constraints
+func (cs Constraints) String() string {
+	csStr := make([]string, len(cs))
+	for i, c := range cs {
+		csStr[i] = c.String()
+	}
+
+	return strings.Join(csStr, ",")
+}
+
+// Check tests if a constraint is validated by the given version.
+func (c *Constraint) Check(v *Version) bool {
+	return c.f(v, c.check)
+}
+
+func (c *Constraint) String() string {
+	return c.original
+}
+
+func parseSingle(v string) (*Constraint, error) {
+	matches := constraintRegexp.FindStringSubmatch(v)
+	if matches == nil {
+		return nil, fmt.Errorf("Malformed constraint: %s", v)
+	}
+
+	check, err := NewVersion(matches[2])
+	if err != nil {
+		return nil, err
+	}
+
+	return &Constraint{
+		f:        constraintOperators[matches[1]],
+		check:    check,
+		original: v,
+	}, nil
+}
+
+func prereleaseCheck(v, c *Version) bool {
+	switch vPre, cPre := v.Prerelease() != "", c.Prerelease() != ""; {
+	case cPre && vPre:
+		// A constraint with a pre-release can only match a pre-release version
+		// with the same base segments.
+		return reflect.DeepEqual(c.Segments64(), v.Segments64())
+
+	case !cPre && vPre:
+		// A constraint without a pre-release can only match a version without a
+		// pre-release.
+		return false
+
+	case cPre && !vPre:
+		// OK, except with the pessimistic operator
+	case !cPre && !vPre:
+		// OK
+	}
+	return true
+}
+
+//-------------------------------------------------------------------
+// Constraint functions
+//-------------------------------------------------------------------
+
+func constraintEqual(v, c *Version) bool {
+	return v.Equal(c)
+}
+
+func constraintNotEqual(v, c *Version) bool {
+	return !v.Equal(c)
+}
+
+func constraintGreaterThan(v, c *Version) bool {
+	return prereleaseCheck(v, c) && v.Compare(c) == 1
+}
+
+func constraintLessThan(v, c *Version) bool {
+	return prereleaseCheck(v, c) && v.Compare(c) == -1
+}
+
+func constraintGreaterThanEqual(v, c *Version) bool {
+	return prereleaseCheck(v, c) && v.Compare(c) >= 0
+}
+
+func constraintLessThanEqual(v, c *Version) bool {
+	return prereleaseCheck(v, c) && v.Compare(c) <= 0
+}
+
+func constraintPessimistic(v, c *Version) bool {
+	// Using a pessimistic constraint with a pre-release, restricts versions to pre-releases
+	if !prereleaseCheck(v, c) || (c.Prerelease() != "" && v.Prerelease() == "") {
+		return false
+	}
+
+	// If the version being checked is naturally less than the constraint, then there
+	// is no way for the version to be valid against the constraint
+	if v.LessThan(c) {
+		return false
+	}
+	// We'll use this more than once, so grab the length now so it's a little cleaner
+	// to write the later checks
+	cs := len(c.segments)
+
+	// If the version being checked has less specificity than the constraint, then there
+	// is no way for the version to be valid against the constraint
+	if cs > len(v.segments) {
+		return false
+	}
+
+	// Check the segments in the constraint against those in the version. If the version
+	// being checked, at any point, does not have the same values in each index of the
+	// constraints segments, then it cannot be valid against the constraint.
+	for i := 0; i < c.si-1; i++ {
+		if v.segments[i] != c.segments[i] {
+			return false
+		}
+	}
+
+	// Check the last part of the segment in the constraint. If the version segment at
+	// this index is less than the constraints segment at this index, then it cannot
+	// be valid against the constraint
+	if c.segments[cs-1] > v.segments[cs-1] {
+		return false
+	}
+
+	// If nothing has rejected the version by now, it's valid
+	return true
+}

--- a/vendor/github.com/hashicorp/go-version/go.mod
+++ b/vendor/github.com/hashicorp/go-version/go.mod
@@ -1,0 +1,1 @@
+module github.com/hashicorp/go-version

--- a/vendor/github.com/hashicorp/go-version/version.go
+++ b/vendor/github.com/hashicorp/go-version/version.go
@@ -1,0 +1,384 @@
+package version
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// The compiled regular expression used to test the validity of a version.
+var (
+	versionRegexp *regexp.Regexp
+	semverRegexp  *regexp.Regexp
+)
+
+// The raw regular expression string used for testing the validity
+// of a version.
+const (
+	VersionRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-?([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+		`?`
+
+	// SemverRegexpRaw requires a separator between version and prerelease
+	SemverRegexpRaw string = `v?([0-9]+(\.[0-9]+)*?)` +
+		`(-([0-9]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)|(-([A-Za-z\-~]+[0-9A-Za-z\-~]*(\.[0-9A-Za-z\-~]+)*)))?` +
+		`(\+([0-9A-Za-z\-~]+(\.[0-9A-Za-z\-~]+)*))?` +
+		`?`
+)
+
+// Version represents a single version.
+type Version struct {
+	metadata string
+	pre      string
+	segments []int64
+	si       int
+	original string
+}
+
+func init() {
+	versionRegexp = regexp.MustCompile("^" + VersionRegexpRaw + "$")
+	semverRegexp = regexp.MustCompile("^" + SemverRegexpRaw + "$")
+}
+
+// NewVersion parses the given version and returns a new
+// Version.
+func NewVersion(v string) (*Version, error) {
+	return newVersion(v, versionRegexp)
+}
+
+// NewSemver parses the given version and returns a new
+// Version that adheres strictly to SemVer specs
+// https://semver.org/
+func NewSemver(v string) (*Version, error) {
+	return newVersion(v, semverRegexp)
+}
+
+func newVersion(v string, pattern *regexp.Regexp) (*Version, error) {
+	matches := pattern.FindStringSubmatch(v)
+	if matches == nil {
+		return nil, fmt.Errorf("Malformed version: %s", v)
+	}
+	segmentsStr := strings.Split(matches[1], ".")
+	segments := make([]int64, len(segmentsStr))
+	si := 0
+	for i, str := range segmentsStr {
+		val, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error parsing version: %s", err)
+		}
+
+		segments[i] = int64(val)
+		si++
+	}
+
+	// Even though we could support more than three segments, if we
+	// got less than three, pad it with 0s. This is to cover the basic
+	// default usecase of semver, which is MAJOR.MINOR.PATCH at the minimum
+	for i := len(segments); i < 3; i++ {
+		segments = append(segments, 0)
+	}
+
+	pre := matches[7]
+	if pre == "" {
+		pre = matches[4]
+	}
+
+	return &Version{
+		metadata: matches[10],
+		pre:      pre,
+		segments: segments,
+		si:       si,
+		original: v,
+	}, nil
+}
+
+// Must is a helper that wraps a call to a function returning (*Version, error)
+// and panics if error is non-nil.
+func Must(v *Version, err error) *Version {
+	if err != nil {
+		panic(err)
+	}
+
+	return v
+}
+
+// Compare compares this version to another version. This
+// returns -1, 0, or 1 if this version is smaller, equal,
+// or larger than the other version, respectively.
+//
+// If you want boolean results, use the LessThan, Equal,
+// GreaterThan, GreaterThanOrEqual or LessThanOrEqual methods.
+func (v *Version) Compare(other *Version) int {
+	// A quick, efficient equality check
+	if v.String() == other.String() {
+		return 0
+	}
+
+	segmentsSelf := v.Segments64()
+	segmentsOther := other.Segments64()
+
+	// If the segments are the same, we must compare on prerelease info
+	if reflect.DeepEqual(segmentsSelf, segmentsOther) {
+		preSelf := v.Prerelease()
+		preOther := other.Prerelease()
+		if preSelf == "" && preOther == "" {
+			return 0
+		}
+		if preSelf == "" {
+			return 1
+		}
+		if preOther == "" {
+			return -1
+		}
+
+		return comparePrereleases(preSelf, preOther)
+	}
+
+	// Get the highest specificity (hS), or if they're equal, just use segmentSelf length
+	lenSelf := len(segmentsSelf)
+	lenOther := len(segmentsOther)
+	hS := lenSelf
+	if lenSelf < lenOther {
+		hS = lenOther
+	}
+	// Compare the segments
+	// Because a constraint could have more/less specificity than the version it's
+	// checking, we need to account for a lopsided or jagged comparison
+	for i := 0; i < hS; i++ {
+		if i > lenSelf-1 {
+			// This means Self had the lower specificity
+			// Check to see if the remaining segments in Other are all zeros
+			if !allZero(segmentsOther[i:]) {
+				// if not, it means that Other has to be greater than Self
+				return -1
+			}
+			break
+		} else if i > lenOther-1 {
+			// this means Other had the lower specificity
+			// Check to see if the remaining segments in Self are all zeros -
+			if !allZero(segmentsSelf[i:]) {
+				//if not, it means that Self has to be greater than Other
+				return 1
+			}
+			break
+		}
+		lhs := segmentsSelf[i]
+		rhs := segmentsOther[i]
+		if lhs == rhs {
+			continue
+		} else if lhs < rhs {
+			return -1
+		}
+		// Otherwis, rhs was > lhs, they're not equal
+		return 1
+	}
+
+	// if we got this far, they're equal
+	return 0
+}
+
+func allZero(segs []int64) bool {
+	for _, s := range segs {
+		if s != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func comparePart(preSelf string, preOther string) int {
+	if preSelf == preOther {
+		return 0
+	}
+
+	var selfInt int64
+	selfNumeric := true
+	selfInt, err := strconv.ParseInt(preSelf, 10, 64)
+	if err != nil {
+		selfNumeric = false
+	}
+
+	var otherInt int64
+	otherNumeric := true
+	otherInt, err = strconv.ParseInt(preOther, 10, 64)
+	if err != nil {
+		otherNumeric = false
+	}
+
+	// if a part is empty, we use the other to decide
+	if preSelf == "" {
+		if otherNumeric {
+			return -1
+		}
+		return 1
+	}
+
+	if preOther == "" {
+		if selfNumeric {
+			return 1
+		}
+		return -1
+	}
+
+	if selfNumeric && !otherNumeric {
+		return -1
+	} else if !selfNumeric && otherNumeric {
+		return 1
+	} else if !selfNumeric && !otherNumeric && preSelf > preOther {
+		return 1
+	} else if selfInt > otherInt {
+		return 1
+	}
+
+	return -1
+}
+
+func comparePrereleases(v string, other string) int {
+	// the same pre release!
+	if v == other {
+		return 0
+	}
+
+	// split both pre releases for analyse their parts
+	selfPreReleaseMeta := strings.Split(v, ".")
+	otherPreReleaseMeta := strings.Split(other, ".")
+
+	selfPreReleaseLen := len(selfPreReleaseMeta)
+	otherPreReleaseLen := len(otherPreReleaseMeta)
+
+	biggestLen := otherPreReleaseLen
+	if selfPreReleaseLen > otherPreReleaseLen {
+		biggestLen = selfPreReleaseLen
+	}
+
+	// loop for parts to find the first difference
+	for i := 0; i < biggestLen; i = i + 1 {
+		partSelfPre := ""
+		if i < selfPreReleaseLen {
+			partSelfPre = selfPreReleaseMeta[i]
+		}
+
+		partOtherPre := ""
+		if i < otherPreReleaseLen {
+			partOtherPre = otherPreReleaseMeta[i]
+		}
+
+		compare := comparePart(partSelfPre, partOtherPre)
+		// if parts are equals, continue the loop
+		if compare != 0 {
+			return compare
+		}
+	}
+
+	return 0
+}
+
+// Equal tests if two versions are equal.
+func (v *Version) Equal(o *Version) bool {
+	if v == nil || o == nil {
+		return v == o
+	}
+
+	return v.Compare(o) == 0
+}
+
+// GreaterThan tests if this version is greater than another version.
+func (v *Version) GreaterThan(o *Version) bool {
+	return v.Compare(o) > 0
+}
+
+// GreaterThanOrEqual tests if this version is greater than or equal to another version.
+func (v *Version) GreaterThanOrEqual(o *Version) bool {
+	return v.Compare(o) >= 0
+}
+
+// LessThan tests if this version is less than another version.
+func (v *Version) LessThan(o *Version) bool {
+	return v.Compare(o) < 0
+}
+
+// LessThanOrEqual tests if this version is less than or equal to another version.
+func (v *Version) LessThanOrEqual(o *Version) bool {
+	return v.Compare(o) <= 0
+}
+
+// Metadata returns any metadata that was part of the version
+// string.
+//
+// Metadata is anything that comes after the "+" in the version.
+// For example, with "1.2.3+beta", the metadata is "beta".
+func (v *Version) Metadata() string {
+	return v.metadata
+}
+
+// Prerelease returns any prerelease data that is part of the version,
+// or blank if there is no prerelease data.
+//
+// Prerelease information is anything that comes after the "-" in the
+// version (but before any metadata). For example, with "1.2.3-beta",
+// the prerelease information is "beta".
+func (v *Version) Prerelease() string {
+	return v.pre
+}
+
+// Segments returns the numeric segments of the version as a slice of ints.
+//
+// This excludes any metadata or pre-release information. For example,
+// for a version "1.2.3-beta", segments will return a slice of
+// 1, 2, 3.
+func (v *Version) Segments() []int {
+	segmentSlice := make([]int, len(v.segments))
+	for i, v := range v.segments {
+		segmentSlice[i] = int(v)
+	}
+	return segmentSlice
+}
+
+// Segments64 returns the numeric segments of the version as a slice of int64s.
+//
+// This excludes any metadata or pre-release information. For example,
+// for a version "1.2.3-beta", segments will return a slice of
+// 1, 2, 3.
+func (v *Version) Segments64() []int64 {
+	result := make([]int64, len(v.segments))
+	copy(result, v.segments)
+	return result
+}
+
+// String returns the full version string included pre-release
+// and metadata information.
+//
+// This value is rebuilt according to the parsed segments and other
+// information. Therefore, ambiguities in the version string such as
+// prefixed zeroes (1.04.0 => 1.4.0), `v` prefix (v1.0.0 => 1.0.0), and
+// missing parts (1.0 => 1.0.0) will be made into a canonicalized form
+// as shown in the parenthesized examples.
+func (v *Version) String() string {
+	var buf bytes.Buffer
+	fmtParts := make([]string, len(v.segments))
+	for i, s := range v.segments {
+		// We can ignore err here since we've pre-parsed the values in segments
+		str := strconv.FormatInt(s, 10)
+		fmtParts[i] = str
+	}
+	fmt.Fprintf(&buf, strings.Join(fmtParts, "."))
+	if v.pre != "" {
+		fmt.Fprintf(&buf, "-%s", v.pre)
+	}
+	if v.metadata != "" {
+		fmt.Fprintf(&buf, "+%s", v.metadata)
+	}
+
+	return buf.String()
+}
+
+// Original returns the original parsed version as-is, including any
+// potential whitespace, `v` prefix, etc.
+func (v *Version) Original() string {
+	return v.original
+}

--- a/vendor/github.com/hashicorp/go-version/version_collection.go
+++ b/vendor/github.com/hashicorp/go-version/version_collection.go
@@ -1,0 +1,17 @@
+package version
+
+// Collection is a type that implements the sort.Interface interface
+// so that versions can be sorted.
+type Collection []*Version
+
+func (v Collection) Len() int {
+	return len(v)
+}
+
+func (v Collection) Less(i, j int) bool {
+	return v[i].LessThan(v[j])
+}
+
+func (v Collection) Swap(i, j int) {
+	v[i], v[j] = v[j], v[i]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -31,6 +31,8 @@ github.com/google/uuid
 github.com/googleapis/gnostic/OpenAPIv2
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
+# github.com/hashicorp/go-version v1.2.1
+github.com/hashicorp/go-version
 # github.com/hashicorp/golang-lru v0.5.1
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru


### PR DESCRIPTION
This PR does the following changes:
- Add support for the v1 version of cStor backup and restore at rest endpoint.
- Add backward compatibility to support v1alpha1 version of cStor backup and restore.
- Add unit test to verify both versions of cStor backup and restore.
- Add CStor backup and restore v1 version CRD's
- Remove CStor backup and restore v1alpha1 version of CRD's while installing. 

**If the changes in this PR are manually verified, list down the scenarios covered**:
- Create backup and restore backup using minio when all the pool-manager supports v1 version(both the crds are installed).
- Create backup and restore backup using minio when few of the pool-manager supports the v1 version and other supports the v1alpha1 version.
```sh
Restore v1alpha1 version
NAMESPACE   NAME                                               BACKUP        VOLUME                                     STATUS
openebs     miniobackup-2d12ffad-ce92-498c-8b11-47f9f1470b2b   miniobackup   pvc-3ee75dba-c0f5-46f1-9301-bafca13a3d61   Done
Restore v1 version
NAMESPACE   NAME                                               BACKUP        VOLUME                                     STATUS
openebs     miniobackup-a754e3a0-3af5-4895-ae7f-d8da2b1f3fca   miniobackup   pvc-3ee75dba-c0f5-46f1-9301-bafca13a3d61   Done
```
- Create backup and restored backup using minio when all the pool-manager supports v1 version(only v1 version of resources are installed).
```sh
Backup v1alpha1 version
error: the server doesn't have a resource type "cstorbackup"
Backup v1 version
NAMESPACE   NAME                                                   VOLUME                                     BACKUP/SCHEDULE   STATUS
percona1    miniobackup-pvc-da2a12fb-7184-4a2e-b1e0-10e0a037c06f   pvc-da2a12fb-7184-4a2e-b1e0-10e0a037c06f   miniobackup       Done
------------
Restore v1 version
NAMESPACE   NAME                                               BACKUP        VOLUME                                     STATUS
openebs     miniobackup-1926478e-c8b1-489b-9330-e18ec2f9c271   miniobackup   pvc-c7b5102e-abac-482a-a78f-cbb7f78062e9   Done
openebs     miniobackup-6738ea67-e36b-4de9-bdb3-7c5ad3dc84a3   miniobackup   pvc-c7b5102e-abac-482a-a78f-cbb7f78062e9   Done
```
- Control plane alone is upgraded but cstor pool-manager is still in older versions
```sh
Backup v1alpha1 version
NAMESPACE   NAME                                                   VOLUME                                     BACKUP/SCHEDULE   STATUS
percona1    miniobackup-pvc-da2a12fb-7184-4a2e-b1e0-10e0a037c06f   pvc-da2a12fb-7184-4a2e-b1e0-10e0a037c06f   miniobackup       Done
```

**Note To Reviewers**:
- Before reviewing code changes please look go through [OEP](https://github.com/openebs/openebs/pull/3072).
- Before merging this PR [API](https://github.com/openebs/api/pull/58) PR needs to be merged.

This PR fixes: https://github.com/openebs/maya/issues/1653