### PR TITLE
feat(gh-pages): add github page content for cstor helm charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
-# cstor-operators
-Collection of OpenEBS cStor Data Engine Operators
+# CStor Charts
+
+The contents of this branch (gh-pages) are published via GitHub pages at https://openebs.github.io/cstor-operators/
+
+This branch contains the following:
+- CStor Helm Chart metadata - [index.yaml](./index.yaml). This file is auto-updated by GitHub Action - Helm 
+Chart Releaser. Please do not modify this file.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+name: CStor Helm Charts
+description: CStor Helm Repository

--- a/index.md
+++ b/index.md
@@ -1,0 +1,39 @@
+# CStor Helm Repository
+
+<img width="300" align="right" alt="OpenEBS Logo" src="https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/stacked/color/openebs-stacked-color.png" xmlns="http://www.w3.org/1999/html">
+
+[Helm3](https://helm.sh) must be installed to use the charts.
+Please refer to Helm's [documentation](https://helm.sh/docs/) to get started.
+
+Once Helm is set up properly, add the repo as follows:
+
+```bash
+$ helm repo add cstor https://openebs.github.io/cstor-operators
+```
+
+You can then run `helm search repo cstor` to see the charts.
+
+#### Update OpenEBS Repo
+
+Once cstor repository has been successfully fetched into the local system, it has to be updated to get the latest version. The cstor repo can be updated using the following command.
+
+```bash
+helm repo update
+```
+
+#### Install using Helm 3
+
+- Assign openebs namespace to the current context:
+```bash
+kubectl config set-context <current_context_name> --namespace=openebs
+```
+
+- If namespace is not created, run the following command
+```bash
+helm install <your-relase-name> cstor/openebs-cstor --create-namespace
+```
+- Else, if namespace is already created, run the following command
+```bash
+helm install <your-relase-name> cstor/openebs-cstor
+```
+

--- a/index.md
+++ b/index.md
@@ -13,7 +13,7 @@ $ helm repo add cstor https://openebs.github.io/cstor-operators
 
 You can then run `helm search repo cstor` to see the charts.
 
-#### Update OpenEBS Repo
+#### Update OpenEBS CStor Repo
 
 Once cstor repository has been successfully fetched into the local system, it has to be updated to get the latest version. The cstor repo can be updated using the following command.
 
@@ -36,4 +36,3 @@ helm install <your-relase-name> cstor/openebs-cstor --create-namespace
 ```bash
 helm install <your-relase-name> cstor/openebs-cstor
 ```
-


### PR DESCRIPTION
This PR adds helm chart install instructions to be displayed at the Github page. 

The page can be viewed at `openebs.github.io/cstor-operators` after the PRs 
#185 and #180 are merged.
Signed-off-by: Ashutosh Kumar <ashutosh.kumar@mayadata.io>