### PR TITLE
fix(typo): Fixes typo in cstor cspc controller log messages

### DIFF
--- a/pkg/controllers/cspc-controller/sync.go
+++ b/pkg/controllers/cspc-controller/sync.go
@@ -74,7 +74,7 @@ func (c *Controller) sync(cspc *cstor.CStorPoolCluster, cspiList *cstor.CStorPoo
 		if err != nil {
 			message := fmt.Sprintf("Could not sync CSPC: {%s}", err.Error())
 			c.recorder.Event(cspc, corev1.EventTypeWarning, "Pool Cleanup", message)
-			klog.Errorf("Could not sync CSPC %s in namesapce %s: {%s}", cspc.Name, cspc.Namespace, err.Error())
+			klog.Errorf("Could not sync CSPC %s in namespace %s: {%s}", cspc.Name, cspc.Namespace, err.Error())
 			return nil
 		}
 
@@ -82,14 +82,14 @@ func (c *Controller) sync(cspc *cstor.CStorPoolCluster, cspiList *cstor.CStorPoo
 		if err != nil {
 			message := fmt.Sprintf("Could not sync CSPC: {%s}", err.Error())
 			c.recorder.Event(cspc, corev1.EventTypeWarning, "Pool Cleanup", message)
-			klog.Errorf("Could not sync CSPC %s in namesapce %s: {%s}", cspc.Name, cspc.Namespace, err.Error())
+			klog.Errorf("Could not sync CSPC %s in namespace %s: {%s}", cspc.Name, cspc.Namespace, err.Error())
 			return nil
 		}
 	}
 
 	cspcGot, err := c.populateVersion(cspc)
 	if err != nil {
-		klog.Errorf("failed to add versionDetails to CSPC %s in namesapce %s :{%s}", cspc.Name, cspc.Namespace, err.Error())
+		klog.Errorf("failed to add versionDetails to CSPC %s in namespace %s :{%s}", cspc.Name, cspc.Namespace, err.Error())
 		return nil
 	}
 
@@ -121,7 +121,7 @@ func (c *Controller) sync(cspc *cstor.CStorPoolCluster, cspiList *cstor.CStorPoo
 
 	cspcGot, err = c.populateDesiredInstances(cspcGot)
 	if err != nil {
-		klog.Errorf("failed to add desired instances to CSPC %s in namesapce %s :{%s}", cspc.Name, cspc.Namespace, err.Error())
+		klog.Errorf("failed to add desired instances to CSPC %s in namespace %s :{%s}", cspc.Name, cspc.Namespace, err.Error())
 		return nil
 	}
 

--- a/pkg/controllers/cstorvolumeconfig/controller.go
+++ b/pkg/controllers/cstorvolumeconfig/controller.go
@@ -165,7 +165,7 @@ func (c *CVCController) syncCVC(cvc *apis.CStorVolumeConfig) error {
 
 	updatedCVC, err := c.populateVersion(cvc)
 	if err != nil {
-		klog.Errorf("failed to add versionDetails to CVC %s in namesapce %s :{%s}", cvc.Name, cvc.Namespace, err.Error())
+		klog.Errorf("failed to add versionDetails to CVC %s in namespace %s :{%s}", cvc.Name, cvc.Namespace, err.Error())
 		return nil
 	}
 

--- a/pkg/snapshot/client.go
+++ b/pkg/snapshot/client.go
@@ -38,8 +38,8 @@ type CommandStatus struct {
 
 // Snapshotter is used to perform snapshot operations on given volume
 type Snapshotter interface {
-	CreateSnapshot(ip, volumeName, namesapce string) (*v1proto.VolumeSnapCreateResponse, error)
-	DestroySnapshot(ip, volumeName, namesapce string) (*v1proto.VolumeSnapDeleteResponse, error)
+	CreateSnapshot(ip, volumeName, snapName string) (*v1proto.VolumeSnapCreateResponse, error)
+	DestroySnapshot(ip, volumeName, snapName string) (*v1proto.VolumeSnapDeleteResponse, error)
 }
 
 // SnapClient is used to perform real snap create and snap delete commands


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

Fixed the typo in cstor operator logs. change namesapce into namespace 
