### PR TITLE
fix(cstor restore): use relevant labels to fetch CSPI name

### DIFF
--- a/pkg/server/cstorvolumeconfig/restore_endpoint.go
+++ b/pkg/server/cstorvolumeconfig/restore_endpoint.go
@@ -533,7 +533,7 @@ func (rOps *restoreAPIOps) getCStorRestoreStatus(
 		rstStatus = restore.Status
 		if restore.Status != cstorapis.RSTCStorStatusDone &&
 			restore.Status != cstorapis.RSTCStorStatusFailed {
-			poolName := restore.Labels[cstortypes.CStorPoolInstanceLabelKey]
+			poolName := restore.Labels[cstortypes.CStorPoolInstanceNameLabelKey]
 			isPoolDown := isPoolManagerDown(rOps.k8sclientset, poolName, namespace)
 			if isPoolDown {
 				rstStatus = cstorapis.RSTCStorStatusFailed

--- a/pkg/server/cstorvolumeconfig/v1alpha1_restore.go
+++ b/pkg/server/cstorvolumeconfig/v1alpha1_restore.go
@@ -30,7 +30,7 @@ func (rOps *restoreAPIOps) getV1Alpha1CStorRestoreStatus(
 		rstStatus = restore.Status
 		if restore.Status != openebsapis.RSTCStorStatusDone &&
 			restore.Status != openebsapis.RSTCStorStatusFailed {
-			poolName := restore.Labels[cstortypes.CStorPoolInstanceLabelKey]
+			poolName := restore.Labels[cstortypes.CStorPoolInstanceNameLabelKey]
 			isPoolDown := isPoolManagerDown(rOps.k8sclientset, poolName, namespace)
 			if isPoolDown {
 				rstStatus = openebsapis.RSTCStorStatusFailed


### PR DESCRIPTION
Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>

This PR fixes the issue to fetch the status of CStorRestore.

**Bug Description**:
Currently, CStorRestore resource is created using one of the label called
`cstorpoolinstance.openebs.io/name: <cspi_name>` but while
fetching the status of CStorRestore we are also fetching Pool-manager
status(Only in a case where CStorRestore status is not in `Done/Failed` state).
To fetch the pool manager we are using the CSPI name from non-existing
label(i.e `openebs.io/cstor-pool-instance`) of CStorRestore resource.
Due to that, there were partial failure errors in velero restore.
