### PR TITLE
fix(backup, restore): create backup and restore in cstor.openebs.io/v1 group

### DIFF
--- a/pkg/server/cstorvolumeconfig/backup_endpoint.go
+++ b/pkg/server/cstorvolumeconfig/backup_endpoint.go
@@ -381,7 +381,8 @@ func (bOps *backupAPIOps) getBackupInterfaceFromPoolVersion(
 	poolVersion string, backup *cstorapis.CStorBackup) (backupHelper, error) {
 	// error will be reported when version doesn't contain any valid version pattern
 	// Ex: dev, ci, master
-	currentVersion, err := version.NewVersion(poolVersion)
+	// Spliting required if version contains RC1, RC2 to make comparisions
+	currentVersion, err := version.NewVersion(strings.Split(poolVersion, "-")[0])
 	if err != nil {
 		// We need to support backup for ci images also
 		if strings.TrimSpace(poolVersion) != "" && !strings.Contains(poolVersion, "dev") {

--- a/pkg/server/cstorvolumeconfig/https_test.go
+++ b/pkg/server/cstorvolumeconfig/https_test.go
@@ -508,6 +508,27 @@ func TestBackupPostEndPoint(t *testing.T) {
 			checkExistenceOfCStorCompletedBackup: true,
 			isV1Version:                          true,
 		},
+		"test backup when pool is in RC versions": {
+			cspcName:    "cspc-disk-pool7",
+			poolVersion: "2.2.0-RC2",
+			cstorBackup: &openebsapis.CStorBackup{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+				},
+				Spec: openebsapis.CStorBackupSpec{
+					BackupName: "backup7",
+					VolumeName: "volume7",
+					BackupDest: "172.102.29.12:3234",
+					SnapName:   "snapshot7",
+				},
+			},
+			snapshotter:                          &snapshot.FakeSnapshotter{},
+			cvrStatus:                            cstorapis.CVRStatusOnline,
+			expectedResponseCode:                 http.StatusOK,
+			verifyBackUpStatus:                   verifyExistenceOfPendingV1Backup,
+			checkExistenceOfCStorCompletedBackup: true,
+			isV1Version:                          true,
+		},
 	}
 	os.Setenv(util.OpenEBSNamespace, "openebs")
 	for name, test := range tests {
@@ -1236,6 +1257,40 @@ func TestRestoreEndPoint(t *testing.T) {
 					Namespace: namespace,
 					Labels: map[string]string{
 						openebstypes.CStorPoolClusterLabelKey: "cspc-cstor-pool8",
+					},
+				},
+				Spec: cstorapis.CStorVolumeConfigSpec{
+					Provision: cstorapis.VolumeProvision{
+						ReplicaCount: 3,
+					},
+				},
+				Status: cstorapis.CStorVolumeConfigStatus{
+					Phase: cstorapis.CStorVolumeConfigPhasePending,
+				},
+			},
+			expectedResponseCode:    http.StatusOK,
+			verifyCStorRestoreCount: true,
+			isV1Version:             true,
+		},
+		"When restore is triggered for pools on v1 supported RC version": {
+			cspcName:    "cspc-cstor-pool9",
+			poolVersion: "2.2.0-RC3",
+			cstorRestore: &openebsapis.CStorRestore{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+				},
+				Spec: openebsapis.CStorRestoreSpec{
+					RestoreName: "restore9",
+					VolumeName:  "volume9",
+					RestoreSrc:  "127.0.0.1:3422",
+				},
+			},
+			cvcObj: &cstorapis.CStorVolumeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "volume9",
+					Namespace: namespace,
+					Labels: map[string]string{
+						openebstypes.CStorPoolClusterLabelKey: "cspc-cstor-pool9",
 					},
 				},
 				Spec: cstorapis.CStorVolumeConfigSpec{

--- a/pkg/server/cstorvolumeconfig/restore_endpoint.go
+++ b/pkg/server/cstorvolumeconfig/restore_endpoint.go
@@ -262,7 +262,7 @@ func createRestore(openebsClient clientset.Interface, restoreObj *cstorapis.CSto
 		if _, ok := cspiToCVRMap[cspi.Name]; !ok {
 			continue
 		}
-		poolVersion, err := version.NewVersion(cspiVersion)
+		poolVersion, err := version.NewVersion(strings.Split(cspiVersion, "-")[0])
 		// If Current version is empty treat it as a ci
 		if err != nil && (cspiVersion != "" && !strings.Contains(cspiVersion, "dev")) {
 			return nil, CodedError(500,


### PR DESCRIPTION
This PR creates backup and restore in `cstor.openebs.io/v1`
group if the pool is greater than or equal to 2.2.0.  

**Note** If CStor pool is in ci or dev version then backup and restore
               will be created in `cstor.openebs.io` group. 

**Bug Description**: Currently code treats `2.2.0-RC1`(pool version)
 is less than `2.2.0`(minimum openebs version to support v1 version
 of backup and restore) due to this backup and restore is created in
`openebs.io` group but the backup/restore the controller will
understand `cstor.openebs.io` group and will not reconcile for resource.

Link: To test versions https://play.golang.org/p/KwHDhCi26Lx comparisons.

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>