### PR TITLE
fix(restore): set targetip on CVRs after restore is completed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ license-check:
        fi
 	@echo "--> Done checking license."
 	@echo
-# If there are any external tools need to be used, they can be added by defining a EXTERNAL_TOOLS variable 
+# If there are any external tools need to be used, they can be added by defining a EXTERNAL_TOOLS variable
 # Bootstrap the build by downloading additional tools
 .PHONY: bootstrap
 bootstrap:
@@ -214,7 +214,7 @@ bootstrap:
 	done
 
 .PHONY: clean
-clean: 
+clean:
 	@echo '--> Cleaning directory...'
 	rm -rf ${GOPATH}/bin/${CSPC_OPERATOR}
 	rm -rf ${GOPATH}/bin/${CVC_OPERATOR}
@@ -225,3 +225,16 @@ clean:
 	@echo
 
 include Makefile.buildx.mk
+
+.PHONY: k8s-deploy
+k8s-deploy:
+	kubectl apply -f https://openebs.github.io/charts/openebs-operator.yaml
+	kubectl apply -f https://openebs.github.io/charts/cstor-operator.yaml
+
+.PHONY: k8s-deploy-devel
+k8s-deploy-devel:
+	kubectl apply -f deploy/rbac.yaml
+	kubectl apply -f deploy/ndm-operator.yaml
+	kubectl apply -f deploy/crds
+	kubectl apply -f deploy/cstor-operator.yaml
+	kubectl apply -f deploy/csi-operator.yaml

--- a/pkg/controllers/cstorvolumeconfig/volume_operations.go
+++ b/pkg/controllers/cstorvolumeconfig/volume_operations.go
@@ -27,6 +27,7 @@ import (
 	clientset "github.com/openebs/api/v2/pkg/client/clientset/versioned"
 
 	"github.com/openebs/cstor-operators/pkg/version"
+	"github.com/openebs/cstor-operators/pkg/volumereplica"
 
 	"github.com/openebs/api/v2/pkg/util"
 
@@ -56,6 +57,10 @@ const (
 	volumeID          = "openebs.io/volumeID"
 	cspiLabel         = "cstorpoolinstance.openebs.io/name"
 	cspiOnline        = "ONLINE"
+
+	// these should be moved to openebs/api
+	pvCreatedByKey        = "openebs.io/created-through"
+	createdThroughRestore = "restore"
 )
 
 // replicaInfo struct is used to pass replica information to
@@ -459,8 +464,8 @@ func (c *CVCController) createCVR(
 	}
 	// Set isRestoreVol annotation on CVR if CVC has
 	// "openebs.io/created-through: restore" annotation
-	if value := claim.GetAnnotations()["openebs.io/created-through"]; value == "restore" {
-		annotations["isRestoreVol"] = "true"
+	if value := claim.GetAnnotations()[pvCreatedByKey]; value == createdThroughRestore {
+		annotations[volumereplica.IsRestoreVol] = "true"
 	}
 	cvrObj, err := c.clientset.CstorV1().CStorVolumeReplicas(openebsNamespace).
 		Get(volume.Name+"-"+string(pool.Name), metav1.GetOptions{})

--- a/pkg/controllers/replica-controller/controller.go
+++ b/pkg/controllers/replica-controller/controller.go
@@ -211,22 +211,6 @@ func NewCStorVolumeReplicaController(
 					return
 				}
 
-				if newCVR.ResourceVersion != oldCVR.ResourceVersion {
-					// cvr modify is not implemented
-					// hence below is commented
-					// ql.Operation = common.QOpModify
-
-					controller.recorder.Event(
-						newCVR,
-						corev1.EventTypeNormal,
-						string(common.SuccessSynced),
-						string(common.MessageModifySynced),
-					)
-
-					// no further handling needed
-					return
-				}
-
 				// finally !!!
 				// push this operation to workqueue
 				ql.Operation = common.QOpSync

--- a/pkg/volumereplica/volumereplica.go
+++ b/pkg/volumereplica/volumereplica.go
@@ -42,6 +42,8 @@ import (
 const (
 	// VolumeReplicaOperator is the name of the tool that makes volume-related operations.
 	VolumeReplicaOperator = "zfs"
+	// Execute is the name of the tool that evaluates the provided command
+	Execute = "/usr/local/bin/execute.sh"
 	// BinaryCapacityUnitSuffix is the suffix for binary capacity unit.
 	BinaryCapacityUnitSuffix = "i"
 	// CreateCmd is the create command for zfs volume.
@@ -70,6 +72,8 @@ const (
 	MaxRestoreRetryCount = 10
 	// RestoreRetryDelay is time(in seconds) to wait before the next attempt for restore transfer
 	RestoreRetryDelay = 5
+	// IsRestoreVol marks CVRs created through restore
+	IsRestoreVol = "isRestoreVol"
 )
 
 const (
@@ -310,7 +314,7 @@ func CreateVolumeReplica(cStorVolumeReplica *cstor.CStorVolumeReplica, fullVolNa
 	return nil
 }
 
-// builldVolumeCreateCommand returns volume create command along with attributes as a string array
+// buildVolumeCreateCommand returns volume create command along with attributes as a string array
 func buildVolumeCreateCommand(cStorVolumeReplica *cstor.CStorVolumeReplica, fullVolName string, quorum bool) []string {
 	var createVolCmd []string
 
@@ -343,7 +347,7 @@ func buildVolumeCreateCommand(cStorVolumeReplica *cstor.CStorVolumeReplica, full
 		)
 	}
 
-	if cStorVolumeReplica.Annotations["isRestoreVol"] != "true" {
+	if cStorVolumeReplica.Annotations[IsRestoreVol] != "true" {
 		createVolCmd = append(createVolCmd,
 			"-o", openebsTargetIP,
 		)
@@ -385,6 +389,33 @@ func buildVolumeCloneCommand(cStorVolumeReplica *cstor.CStorVolumeReplica, snapN
 	return cloneVolCmd
 }
 
+func SetTargetIp(fullVolName, targetIp string) error {
+	out, err := zcmd.NewVolumeSetProperty().
+		WithProperty("io.openebs:targetip", targetIp).
+		WithDataset(fullVolName).
+		Execute()
+	if err != nil {
+		return errors.Wrapf(err, "failed to set target ip to %s %s", fullVolName, string(out))
+	}
+
+	return nil
+}
+
+func GetTargetIp(fullVolName string) (string, error) {
+	ret, err := zcmd.NewVolumeGetProperty().
+		WithScriptedMode(true).
+		WithParsableMode(true).
+		WithField("value").
+		WithProperty("io.openebs:targetip").
+		WithDataset(fullVolName).
+		Execute()
+
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to get target ip: %s", fullVolName)
+	}
+	return strings.Split(string(ret), "\n")[0], nil
+}
+
 // ToDo: Move to backup package
 
 // CreateVolumeBackup sends cStor snapshots to remote location specified by cstorbackup.
@@ -400,7 +431,7 @@ func CreateVolumeBackup(bkp *cstor.CStorBackup) error {
 	klog.Infof("Backup Command for volume: %v created, Cmd: %v\n", bkp.Spec.VolumeName, cmd)
 
 	for retryCount < MaxBackupRetryCount {
-		stdoutStderr, err = RunnerVar.RunCombinedOutput("/usr/local/bin/execute.sh", cmd...)
+		stdoutStderr, err = RunnerVar.RunCombinedOutput(Execute, cmd...)
 		if err != nil {
 			klog.Errorf("Unable to start backup %s error: %v retry: %v :%s", bkp.Spec.VolumeName, string(stdoutStderr), retryCount, err.Error())
 			retryCount++
@@ -428,7 +459,7 @@ func CreateVolumeBackup(bkp *cstor.CStorBackup) error {
 
 // ToDo: Move this to backup package
 
-// builldVolumeBackupCommand returns volume create command along with attributes as a string array
+// buildVolumeBackupCommand returns volume create command along with attributes as a string array
 func buildVolumeBackupCommand(poolName, fullVolName, oldSnapName, newSnapName, backupDest string) []string {
 	var startBackupCmd []string
 
@@ -456,7 +487,7 @@ func CreateVolumeRestore(rst *cstor.CStorRestore) error {
 	klog.Infof("Restore Command for volume: %v created, Cmd: %v\n", rst.Spec.VolumeName, cmd)
 
 	for retryCount < MaxRestoreRetryCount {
-		stdoutStderr, err = RunnerVar.RunCombinedOutput("/usr/local/bin/execute.sh", cmd...)
+		stdoutStderr, err = RunnerVar.RunCombinedOutput(Execute, cmd...)
 		if err != nil {
 			klog.Errorf("Unable to start restore %s. error : %v.. trying again", rst.Spec.VolumeName, string(stdoutStderr))
 			time.Sleep(RestoreRetryDelay * time.Second)
@@ -472,7 +503,7 @@ func CreateVolumeRestore(rst *cstor.CStorRestore) error {
 			"rname", rst.Spec.VolumeName,
 		)
 	} else {
-		alertlog.Logger.Errorw("",
+		alertlog.Logger.Infow("",
 			"eventcode", "cstor.volume.restore.success",
 			"msg", "Successfully restored CStor volume",
 			"rname", rst.Spec.VolumeName,


### PR DESCRIPTION
Auto-setting of targetip on CVR if openebs.io/restore-completed is found

## Pull Request template

**Why is this PR required? What issue does it fix?**:
Currently, users have to set targetip on CVRs after restore. Corresponding change in https://github.com/openebs/velero-plugin/pull/131 will mark CVRs which needs to update the targetip. Changes in this PR will check the annotation and set the targetip.


**What this PR does?**:
Sets targetip on CVRs marked with openebs.io/restore-completed annotation.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
`make test` in velero-plugin repository with changes deployed.

**Any additional information for your reviewer?** : 
_Mention if this PR is part of any design or a continuation of previous PRs_

related maya PR: https://github.com/openebs/maya/pull/1761
related velero-plugin PR: https://github.com/openebs/velero-plugin/pull/131

**Checklist:**
- [x] Fixes https://github.com/openebs/velero-plugin/issues/127
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated? 
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track: 
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: 


