### PR TITLE
refact(build): run only amd64 and arm64 builds

### DIFF
--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -29,7 +29,7 @@ endif
 
 # default list of platforms for which multiarch image is built
 ifeq (${PLATFORMS}, )
-	export PLATFORMS="linux/amd64,linux/arm64,linux/ppc64le"
+	export PLATFORMS="linux/amd64,linux/arm64"
 endif
 
 # if IMG_RESULT is unspecified, by default the image will be pushed to registry


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

Enabling more than two arch in the multi-arch builds
is resulting in increased build times as well as
intermittent failures in running the builds.

Limiting to two archs - amd64 and arm64 for now.