### PR TITLE
fix(build): copy binaries instead of folders

### DIFF
--- a/build/cspc-operator/cspc-operator.Dockerfile
+++ b/build/cspc-operator/cspc-operator.Dockerfile
@@ -63,6 +63,6 @@ LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
-COPY --from=build /go/src/github.com/openebs/cstor-operator/bin/cspc-operator /usr/local/bin/cspc-operator
+COPY --from=build /go/src/github.com/openebs/cstor-operator/bin/cspc-operator/cspc-operator /usr/local/bin/cspc-operator
 
 ENTRYPOINT ["/usr/local/bin/cspc-operator"]

--- a/build/cvc-operator/cvc-operator.Dockerfile
+++ b/build/cvc-operator/cvc-operator.Dockerfile
@@ -63,7 +63,7 @@ LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
-COPY --from=build /go/src/github.com/openebs/cstor-operator/bin/cvc-operator /usr/local/bin/cvc-operator
+COPY --from=build /go/src/github.com/openebs/cstor-operator/bin/cvc-operator/cvc-operator /usr/local/bin/cvc-operator
 COPY --from=build /go/src/github.com/openebs/cstor-operator/build/cvc-operator/entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/entrypoint.sh
 

--- a/build/pool-manager/pool-manager.Dockerfile
+++ b/build/pool-manager/pool-manager.Dockerfile
@@ -60,7 +60,7 @@ LABEL org.label-schema.build-date=$DBUILD_DATE
 LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
 LABEL org.label-schema.url=$DBUILD_SITE_URL
 
-COPY --from=build /go/src/github.com/openebs/cstor-operator/bin/pool-manager /usr/local/bin/
+COPY --from=build /go/src/github.com/openebs/cstor-operator/bin/pool-manager/pool-manager /usr/local/bin/
 COPY --from=build /go/src/github.com/openebs/cstor-operator/build/pool-manager/entrypoint.sh /usr/local/bin/
 
 RUN echo '#!/bin/bash\nif [ $# -lt 1 ]; then\n\techo "argument missing"\n\texit 1\nfi\neval "$*"\n' >> /usr/local/bin/execute.sh

--- a/build/volume-manager/volume-manager.Dockerfile
+++ b/build/volume-manager/volume-manager.Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get -y install rsyslog
 
 RUN mkdir -p /usr/local/etc/istgt
 
-COPY --from=build /go/src/github.com/openebs/cstor-operator/bin/volume-manager /usr/local/bin/
+COPY --from=build /go/src/github.com/openebs/cstor-operator/bin/volume-manager/volume-manager /usr/local/bin/
 COPY --from=build /go/src/github.com/openebs/cstor-operator/build/volume-manager/entrypoint.sh /usr/local/bin/
 
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>
The copy command in the buildx Dockerfiles is trying to copy the folder instead of the binaries which causes this error
```
Warning  Failed     4s (x4 over 51s)   kubelet, e2e1-node3  Error: failed to start container "cspc-operator": Error response from daemon: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"/usr/local/bin/cspc-operator\": permission denied": unknown
```

![image](https://user-images.githubusercontent.com/16064787/99142923-7cb6f800-267f-11eb-9b7a-9b1eeb1ffdd5.png)
