### PR TITLE
fix(cspc): cleanup pending bdcs on cspc deletion

### DIFF
--- a/changelogs/unreleased/210-shubham14bajpai
+++ b/changelogs/unreleased/210-shubham14bajpai
@@ -1,0 +1,1 @@
+fix(cspc): cleanup pending bdcs on cspc deletion

--- a/pkg/controllers/cspc-controller/sync.go
+++ b/pkg/controllers/cspc-controller/sync.go
@@ -270,7 +270,9 @@ func (c *Controller) removeCSPCFinalizer(cspc *cstor.CStorPoolCluster) error {
 			LabelSelector: string(types.CStorPoolClusterLabelKey) + "=" + cspc.Name,
 		},
 	)
-
+	if err != nil {
+		return err
+	}
 	for _, bdcItem := range bdcList.Items {
 		bdcItem := bdcItem // pin it
 		bdcObj := &bdcItem

--- a/pkg/controllers/cspc-controller/sync.go
+++ b/pkg/controllers/cspc-controller/sync.go
@@ -25,6 +25,7 @@ import (
 	cstor "github.com/openebs/api/v2/pkg/apis/cstor/v1"
 	"github.com/openebs/api/v2/pkg/apis/types"
 	clientset "github.com/openebs/api/v2/pkg/client/clientset/versioned"
+	"github.com/openebs/api/v2/pkg/util"
 	"github.com/openebs/cstor-operators/pkg/cspc/algorithm"
 	"github.com/openebs/cstor-operators/pkg/version"
 	"github.com/pkg/errors"
@@ -259,6 +260,25 @@ func (c *Controller) removeCSPCFinalizer(cspc *cstor.CStorPoolCluster) error {
 	if len(cspList.Items) > 0 {
 		return errors.Wrap(err, "failed to remove CSPC finalizer on associated resources as "+
 			"CSPI(s) still exists for CSPC")
+	}
+
+	// If the BD(s) are claimed and the CSPI(s) do not spawn up for some reason,
+	// the pending BDC(s) finalizer don't get removed automatically.
+	// The below code handles cleanup for such cases.
+	bdcList, err := c.GetStoredOpenebsVersionClient().BlockDeviceClaims(cspc.Namespace).List(
+		metav1.ListOptions{
+			LabelSelector: string(types.CStorPoolClusterLabelKey) + "=" + cspc.Name,
+		},
+	)
+
+	for _, bdcItem := range bdcList.Items {
+		bdcItem := bdcItem // pin it
+		bdcObj := &bdcItem
+		bdcObj.Finalizers = util.RemoveString(bdcObj.Finalizers, types.CSPCFinalizer)
+		bdcObj, err = c.GetStoredOpenebsVersionClient().BlockDeviceClaims(cspc.Namespace).Update(bdcObj)
+		if err != nil {
+			return errors.Wrapf(err, "failed to remove finalizers from bdc %s", bdcItem.Name)
+		}
 	}
 
 	cspc.RemoveFinalizer(types.CSPCFinalizer)

--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -22,6 +22,7 @@ var (
 	validCurrentVersions = map[string]bool{
 		"1.10.0": true, "1.11.0": true, "1.12.0": true,
 		"2.0.0": true, "2.1.0": true, "2.2.0": true, "2.3.0": true,
+		"2.4.0": true,
 	}
 	validDesiredVersion = strings.Split(GetVersion(), "-")[0]
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**What this PR does:**
This PR fixes the cleanup issue of BDCs when the CSPIs doesn't get provisioned and CSPC is deleted. 

**How to replicate the scenario?**
Setup the cstor-operator yaml and check whether the BDs are active. Then scale down the ndm-operator deployment, this will prevent the BDCs from getting bound. If we delete the CPSC now the BDCs get the deletion timestamp but the cspc-operator does not remove the finalizer from the pending BDCs.

Tested the below code in the same scenario and the BDCs got cleaned up successfully.