### PR TITLE
fix(action): fix release workflow to run only tags with `v` prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@
 name: release
 
 on:
-  create:
+  push:
     tags:
       - 'v*'
 


### PR DESCRIPTION
Modify release workflow to run only when tags with `v` prefix are pushed.
This is required so that chart releases does not trigger a release workflow