### PR TITLE
fix(charts): make the cvc operator service labels consistent with operator

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.1
+version: 2.5.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.5.0

--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -118,6 +118,13 @@ Create component labels cstor cvc operator
 openebs.io/component-name: {{ .Values.cvcOperator.componentName | quote }}
 {{- end -}}
 
+{{/*
+Create component labels cstor cvc operator service
+*/}}
+{{- define "cstor.cvcOperatorService.componentLabels" -}}
+openebs.io/component-name: {{ printf "%s-svc" .Values.cvcOperator.componentName | quote }}
+{{- end -}}
+
 
 {{/*
 Create labels for cstor cvc operator
@@ -126,6 +133,15 @@ Create labels for cstor cvc operator
 {{ include "cstor.common.metaLabels" . }}
 {{ include "cstor.cvcOperator.matchLabels" . }}
 {{ include "cstor.cvcOperator.componentLabels" . }}
+{{- end -}}
+
+{{/*
+Create labels for cstor cvc operator service
+*/}}
+{{- define "cstor.cvcOperatorService.labels" -}}
+{{ include "cstor.common.metaLabels" . }}
+{{ include "cstor.cvcOperator.matchLabels" . }}
+{{ include "cstor.cvcOperatorService.componentLabels" . }}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/charts/templates/cvc-operator-service.yaml
+++ b/deploy/helm/charts/templates/cvc-operator-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ template "cstor.fullname" . }}-cvc-operator-svc
   labels:
-    {{- include "cstor.cvcOperator.labels" . | nindent 4 }}
+    {{- include "cstor.cvcOperatorService.labels" . | nindent 4 }}
 spec:
   ports:
     - name: api


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR makes the cvc operator service labels consistent with the operator yaml. This label is used by external operators like velero so consistency is necessary.
ref: https://github.com/openebs/charts/blob/ac87cc4dfb5bcb93b752d7947af30c143f3cadb8/cstor-operator.yaml#L4422