### PR TITLE
fix(webhook): cleanup validatingwebhook config on openebs namespace deletion

### DIFF
--- a/pkg/webhook/namespace.go
+++ b/pkg/webhook/namespace.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2021 The OpenEBS Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"fmt"
+
+	"k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog"
+)
+
+func (wh *webhook) validateNamespace(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
+	req := ar.Request
+	response := &v1beta1.AdmissionResponse{}
+	response.Allowed = true
+	openebsNamespace, err := getOpenebsNamespace()
+	if err != nil {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: fmt.Sprintf("error getting OPENEBS_NAMESPACE env %s: %v", req.Name, err.Error()),
+		}
+		return response
+	}
+	// validates only if requested operation is DELETE
+	if openebsNamespace == req.Name && req.Operation == v1beta1.Delete {
+		return wh.validateNamespaceDeleteRequest(req)
+	}
+	klog.V(2).Info("Admission wehbook for Namespace module not " +
+		"configured for operations other than DELETE")
+	return response
+}
+
+func (wh *webhook) validateNamespaceDeleteRequest(req *v1beta1.AdmissionRequest) *v1beta1.AdmissionResponse {
+	response := &v1beta1.AdmissionResponse{}
+	response.Allowed = true
+	svcLabel := "openebs.io/controller-service=jiva-controller-svc"
+
+	msg := fmt.Sprintf("either BDCs or services with the label %s exists in the namespace %s.", svcLabel, req.Name)
+
+	// ignore the Delete request of Namespace if resource name is empty
+	if req.Name == "" {
+		return response
+	}
+
+	bdcList, err := wh.clientset.OpenebsV1alpha1().
+		BlockDeviceClaims(req.Name).
+		List(metav1.ListOptions{})
+	if err != nil {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: fmt.Sprintf("error listing BDC in namespace %s: %v", req.Name, err.Error()),
+		}
+		return response
+	}
+
+	if len(bdcList.Items) != 0 {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: msg,
+		}
+		return response
+	}
+
+	svcList, err := wh.kubeClient.CoreV1().Services(req.Name).
+		List(metav1.ListOptions{
+			LabelSelector: svcLabel,
+		})
+	if err != nil {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: fmt.Sprintf("error listing svc in namespace %s: %v", req.Name, err.Error()),
+		}
+		return response
+	}
+
+	if len(svcList.Items) != 0 {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: msg,
+		}
+		return response
+	}
+	// Delete the validatingWebhookConfiguration only if its a delete request to
+	// delete openebs namespace
+	err = wh.kubeClient.AdmissionregistrationV1().
+		ValidatingWebhookConfigurations().
+		Delete(validatorWebhook, &metav1.DeleteOptions{})
+	if err != nil {
+		response.Allowed = false
+		response.Result = &metav1.Status{
+			Message: err.Error(),
+		}
+		return response
+	}
+	return response
+}

--- a/pkg/webhook/util.go
+++ b/pkg/webhook/util.go
@@ -14,7 +14,11 @@
 
 package webhook
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 const (
 	unit = 1024
@@ -32,4 +36,19 @@ func ByteCount(b uint64) string {
 	}
 	return fmt.Sprintf("%d%c",
 		uint64(b)/uint64(div), "KMGTPE"[index])
+}
+
+// if currentversion is less `<` then new version (return true in case of equal version)
+// TODO use version lib to properly handle versions https://github.com/hashicorp/go-version
+func IsCurrentLessThanNewVersion(old, new string) bool {
+	oldVersions := strings.Split(strings.Split(old, "-")[0], ".")
+	newVersions := strings.Split(strings.Split(new, "-")[0], ".")
+	for i := 0; i < len(oldVersions); i++ {
+		oldVersion, _ := strconv.Atoi(oldVersions[i])
+		newVersion, _ := strconv.Atoi(newVersions[i])
+		if oldVersion > newVersion {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -182,13 +182,16 @@ func validationRequired(ignoredList []string, metadata *metav1.ObjectMeta) bool 
 	return required
 }
 
-// validate validates the persistentvolumeclaim(PVC) create, delete request
+// validate validates the different openebs resource related operations
 func (wh *webhook) validate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	req := ar.Request
 	response := &v1beta1.AdmissionResponse{}
 	response.Allowed = true
 	klog.Info("Admission webhook request received")
 	switch req.Kind.Kind {
+	case "Namespace":
+		klog.V(2).Infof("Admission webhook request for type %s", req.Kind.Kind)
+		return wh.validateNamespace(ar)
 	case "PersistentVolumeClaim":
 		klog.V(2).Infof("Admission webhook request for type %s", req.Kind.Kind)
 		return wh.validatePVC(ar)
@@ -198,6 +201,7 @@ func (wh *webhook) validate(ar *v1beta1.AdmissionReview) *v1beta1.AdmissionRespo
 	case "CStorVolumeConfig":
 		klog.V(2).Infof("Admission webhook request for type %s", req.Kind.Kind)
 		return wh.validateCVC(ar)
+
 	default:
 		klog.V(2).Infof("Admission webhook not configured for type %s", req.Kind.Kind)
 		return response


### PR DESCRIPTION
- Add the openebs namespace delete validation checks
- Handle the `validatingwebhookconfiguration` garbage collection  issue due to invalid cross-namespace ownerReference checks introduced in k8s 1.20+

Refer:openebs/openebs#3338

from k8s 1.20+ onwards Cluster-scoped dependents can only specify cluster-scoped owners. In v1.20+, if a cluster-scoped dependent specifies a namespaced kind as an owner, it is treated as having an unresolveable owner reference, and is not able to be garbage collected.

In v1.20+, if the garbage collector detects an invalid cross-namespace ownerReference, or a cluster-scoped dependent with an ownerReference referencing a namespaced kind, a warning Event with a reason of OwnerRefInvalidNamespace and an involvedObject of the invalid dependent is reported. 

You can check for that kind of Event by running
```
kubectl get events -A --field-selector=reason=OwnerRefInvalidNamespace.
```

**Note:**  We have to think about how to handle the deletion if only cstor specific components has been removed from the cluster in openebs namespace, or may be webhook deployment is scaled down due to some reason. 

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>