### PR TITLE
fix(action): auto assign failure due to filename error

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -2,7 +2,7 @@ name: 'Auto Assign PRs'
 
 # pull_request_target means that this will run on pull requests, but in the context of the base repo.
 # This should mean PRs from forks are supported.
-on: 
+on:
   pull_request_target:
     types: [opened, reopened, sychronize, ready_for_review]
 
@@ -10,7 +10,7 @@ jobs:
   add-reviewers:
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.1.1
-        with: 
-          configuration-path: ".github/auto_assign.yml"
-          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: kentaro-m/auto-assign-action@v1.1.2
+        with:
+          configuration-path: ".github/auto_assign.yaml"
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

There was a typo in the config file name yml vs yaml after fixing the name action run correctly. verified the run here https://github.com/prateekpandey14/cstor-operators/pull/7/checks?check_run_id=1959361188

**Note:** auto assign action is failing here in PR since the action workflow files are not updated yet in master branch, once the PR merged, it will work fine for future pull requests 