### PR TITLE
chore(k8s): updated csi driver version to v1

### DIFF
--- a/deploy/csi-operator.yaml
+++ b/deploy/csi-operator.yaml
@@ -775,7 +775,7 @@ status:
   storedVersions: []
 ---
 
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.7.1
+version: 2.7.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.7.0

--- a/deploy/helm/charts/templates/csi-driver.yaml
+++ b/deploy/helm/charts/templates/csi-driver.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.csiDriver.create -}}
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: cstor.csi.openebs.io

--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -23,6 +23,7 @@ var (
 		"1.10.0": true, "1.11.0": true, "1.12.0": true,
 		"2.0.0": true, "2.1.0": true, "2.2.0": true, "2.3.0": true,
 		"2.4.0": true, "2.4.1": true, "2.5.0": true, "2.6.0": true, "2.7.0": true,
+		"2.8.0": true,
 	}
 	validDesiredVersion = strings.Split(GetVersion(), "-")[0]
 )


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

With k8s v1.22 the v1beta1 for various resources will no longer be supported. This PR updates the csi driver api version to v1.

This PR also bumps the version matrix for v2.8.0