### PR TITLE
refact(actions): use build & push action instead of makefile

### DIFF
--- a/.github/workflows/auto_assign_prs.yml
+++ b/.github/workflows/auto_assign_prs.yml
@@ -4,7 +4,7 @@ name: 'Auto Assign PRs'
 # This should mean PRs from forks are supported.
 on:
   pull_request_target:
-    types: [opened, reopened, sychronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 jobs:
   add-reviewers:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -354,6 +354,7 @@ jobs:
             DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
             DBUILD_SITE_URL=https://openebs.io
             BRANCH=${{ env.BRANCH }}
+            BASE_IMAGE=${{ env.IMAGE_ORG }}/cstor-base:${{ env.TAG }}
   
   volume-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   lint:
-    if: ${{ (github.event.ref_type == 'branch') }}
+    if: ${{ (github.event.ref_type != 'tag') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -43,7 +43,7 @@ jobs:
           exclude: './.git/*,./vendor/*'
 
   unit-tests:
-    if: ${{ (github.event.ref_type == 'branch') }}
+    if: ${{ (github.event.ref_type != 'tag') }}
     name: unit tests 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,14 +14,20 @@
 name: build
 
 on:
+  create:
   push:
+    branches:
+    - 'master'
+    - 'v*'
     paths-ignore:
     - 'docs/**'
     - 'deploy/helm/**'
     - 'changelogs/**'
+    - 'CHANGELOG.md'
 
 jobs:
   lint:
+    if: ${{ (github.event.ref_type == 'branch') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,6 +43,7 @@ jobs:
           exclude: './.git/*,./vendor/*'
 
   unit-tests:
+    if: ${{ (github.event.ref_type == 'branch') }}
     name: unit tests 
     runs-on: ubuntu-latest
     steps:
@@ -88,7 +95,7 @@ jobs:
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
       
       - name: Build images locally
-        run: make all.amd64 || exit 1;
+        run: make all || exit 1;
       
       - name: Running tests
         run: ./ci/sanity/install.sh && ./ci/sanity/sanity.sh
@@ -100,6 +107,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
       - name: Set tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
@@ -110,10 +123,28 @@ jobs:
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cspc-operator
+            quay.io/${{ env.IMAGE_ORG }}/cspc-operator
+          tag-latest: false
+          tag-custom-only: true
+          tag-custom: |
+            ${{ env.TAG }}
+
       - name: Print Tag info
         run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${TAG}"
+          echo "${{ steps.docker_meta.outputs.tags }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -132,12 +163,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.cspc-operator
-          make buildx.push.cspc-operator
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/cspc-operator/cspc-operator.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_SITE_URL=https://openebs.io
+            BRANCH=${{ env.BRANCH }}
 
   cvc-operator:
     runs-on: ubuntu-latest
@@ -146,6 +192,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
       - name: Set tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
@@ -156,10 +208,28 @@ jobs:
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cvc-operator
+            quay.io/${{ env.IMAGE_ORG }}/cvc-operator
+          tag-latest: false
+          tag-custom-only: true
+          tag-custom: |
+            ${{ env.TAG }}
+
       - name: Print Tag info
         run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${TAG}"
+          echo "${{ steps.docker_meta.outputs.tags }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -178,12 +248,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.cvc-operator
-          make buildx.push.cvc-operator
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/cvc-operator/cvc-operator.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_SITE_URL=https://openebs.io
+            BRANCH=${{ env.BRANCH }}
   
   pool-manager:
     runs-on: ubuntu-latest
@@ -192,6 +277,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
       - name: Set tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
@@ -202,10 +293,28 @@ jobs:
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cstor-pool-manager
+            quay.io/${{ env.IMAGE_ORG }}/cstor-pool-manager
+          tag-latest: false
+          tag-custom-only: true
+          tag-custom: |
+            ${{ env.TAG }}
+
       - name: Print Tag info
         run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${TAG}"
+          echo "${{ steps.docker_meta.outputs.tags }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -224,12 +333,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.pool-manager
-          make buildx.push.pool-manager
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/pool-manager/pool-manager.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_SITE_URL=https://openebs.io
+            BRANCH=${{ env.BRANCH }}
   
   volume-manager:
     runs-on: ubuntu-latest
@@ -238,6 +362,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
       - name: Set tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
@@ -248,10 +378,28 @@ jobs:
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cstor-volume-manager
+            quay.io/${{ env.IMAGE_ORG }}/cstor-volume-manager
+          tag-latest: false
+          tag-custom-only: true
+          tag-custom: |
+            ${{ env.TAG }}
+
       - name: Print Tag info
         run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${TAG}"
+          echo "${{ steps.docker_meta.outputs.tags }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -270,12 +418,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.volume-manager
-          make buildx.push.volume-manager
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/volume-manager/volume-manager.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_SITE_URL=https://openebs.io
+            BRANCH=${{ env.BRANCH }}
 
   cstor-webhook:
     runs-on: ubuntu-latest
@@ -284,6 +447,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
+
       - name: Set tag
         run: |
           BRANCH="${GITHUB_REF##*/}"
@@ -294,10 +463,28 @@ jobs:
           echo "TAG=${CI_TAG}" >> $GITHUB_ENV
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cstor-webhook
+            quay.io/${{ env.IMAGE_ORG }}/cstor-webhook
+          tag-latest: false
+          tag-custom-only: true
+          tag-custom: |
+            ${{ env.TAG }}
+
       - name: Print Tag info
         run: |
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${TAG}"
+          echo "${{ steps.docker_meta.outputs.tags }}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -316,9 +503,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.cstor-webhook
-          make buildx.push.cstor-webhook
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/cstor-webhook/cstor-webhook.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_SITE_URL=https://openebs.io
+            BRANCH=${{ env.BRANCH }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
             ${{ steps.docker_meta.outputs.tags }}
           build-args: |
             DBUILD_DATE=${{ steps.date.outputs.DATE }}
-            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
             DBUILD_SITE_URL=https://openebs.io
             BRANCH=${{ env.BRANCH }}
 
@@ -266,7 +266,7 @@ jobs:
             ${{ steps.docker_meta.outputs.tags }}
           build-args: |
             DBUILD_DATE=${{ steps.date.outputs.DATE }}
-            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
             DBUILD_SITE_URL=https://openebs.io
             BRANCH=${{ env.BRANCH }}
   
@@ -351,7 +351,7 @@ jobs:
             ${{ steps.docker_meta.outputs.tags }}
           build-args: |
             DBUILD_DATE=${{ steps.date.outputs.DATE }}
-            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
             DBUILD_SITE_URL=https://openebs.io
             BRANCH=${{ env.BRANCH }}
             BASE_IMAGE=${{ env.IMAGE_ORG }}/cstor-base:${{ env.TAG }}
@@ -437,7 +437,7 @@ jobs:
             ${{ steps.docker_meta.outputs.tags }}
           build-args: |
             DBUILD_DATE=${{ steps.date.outputs.DATE }}
-            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
             DBUILD_SITE_URL=https://openebs.io
             BRANCH=${{ env.BRANCH }}
 
@@ -522,6 +522,6 @@ jobs:
             ${{ steps.docker_meta.outputs.tags }}
           build-args: |
             DBUILD_DATE=${{ steps.date.outputs.DATE }}
-            DBUILD_REPO_URL=https://github.com/openebs/cspc-operators
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
             DBUILD_SITE_URL=https://openebs.io
             BRANCH=${{ env.BRANCH }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,6 +20,7 @@ on:
       - 'docs/**'
       - 'deploy/helm/**'
       - 'changelogs/**'
+      - 'CHANGELOG.md'
     branches:
       # on pull requests to master and release branches
       - master
@@ -59,10 +60,15 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Build Image
-        env:
-          IMG_RESULT: cache
-        run: make docker.buildx.cspc-operator
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/cspc-operator/cspc-operator.Dockerfile
+          push: false
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            openebs/cspc-operator:ci
 
   cvc-operator:
     runs-on: ubuntu-latest
@@ -82,10 +88,15 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Build Image
-        env:
-          IMG_RESULT: cache
-        run: make docker.buildx.cvc-operator
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/cvc-operator/cvc-operator.Dockerfile
+          push: false
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            openebs/cvc-operator:ci
 
   pool-manager:
     runs-on: ubuntu-latest
@@ -105,10 +116,15 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Build Image
-        env:
-          IMG_RESULT: cache
-        run: make docker.buildx.pool-manager
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/pool-manager/pool-manager.Dockerfile
+          push: false
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            openebs/cstor-pool-manager:ci
 
   volume-manager:
     runs-on: ubuntu-latest
@@ -128,10 +144,15 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Build Image
-        env:
-          IMG_RESULT: cache
-        run: make docker.buildx.volume-manager
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/volume-manager/volume-manager.Dockerfile
+          push: false
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            openebs/cstor-volume-manager:ci
   
   cstor-webhook:
     runs-on: ubuntu-latest
@@ -151,10 +172,15 @@ jobs:
         with:
           version: v0.5.1
 
-      - name: Build Image
-        env:
-          IMG_RESULT: cache
-        run: make docker.buildx.cstor-webhook
+      - name: Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/cstor-webhook/cstor-webhook.Dockerfile
+          push: false
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            openebs/cstor-webhook:ci
 
   unit-tests:
     name: unit tests 
@@ -205,7 +231,7 @@ jobs:
           echo "BRANCH=${BRANCH}" >> $GITHUB_ENV
 
       - name: Build images locally
-        run: make all.amd64 || exit 1;
+        run: make all || exit 1;
       
       - name: Running tests
         run: ./ci/sanity/install.sh && ./ci/sanity/sanity.sh

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -125,6 +125,8 @@ jobs:
           platforms: linux/amd64, linux/arm64
           tags: |
             openebs/cstor-pool-manager:ci
+          build-args: |
+            BASE_IMAGE=openebs/cstor-base:ci
 
   volume-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,7 @@ jobs:
             DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
             DBUILD_SITE_URL=https://openebs.io
             RELEASE_TAG=${{ env.RELEASE_TAG }}
+            BASE_IMAGE=${{ env.IMAGE_ORG }}/cstor-base:${{ env.RELEASE_TAG }}
 
   volume-manager:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,6 @@ on:
 jobs:  
   cspc-operator:
     runs-on: ubuntu-latest
-    needs: ['e2e-tests']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -103,7 +102,6 @@ jobs:
 
   cvc-operator:
     runs-on: ubuntu-latest
-    needs: ['e2e-tests']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -183,7 +181,6 @@ jobs:
 
   pool-manager:
     runs-on: ubuntu-latest
-    needs: ['e2e-tests']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -264,7 +261,6 @@ jobs:
 
   volume-manager:
     runs-on: ubuntu-latest
-    needs: ['e2e-tests']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -344,7 +340,6 @@ jobs:
 
   cstor-webhook:
     runs-on: ubuntu-latest
-    needs: ['e2e-tests']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,3 +416,19 @@ jobs:
             DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
             DBUILD_SITE_URL=https://openebs.io
             RELEASE_TAG=${{ env.RELEASE_TAG }}
+
+  downstream-tagging:
+    runs-on: ubuntu-latest
+    needs: ['cspc-operator', 'cvc-operator', 'pool-manager', 'volume-manager', 'cstor-webhook']
+    steps:
+      - name: Downstream tagging
+        uses: akhilerm/openebs-release-mgmt@v1.1.0
+        with:
+          tag-name: ${{ github.ref }}
+          body: 'Release created from cstor-operators'
+          repo: |
+            velero-plugin
+            cstor-csi
+            upgrade
+          # GR_TOKEN secret is the access token to perform github releases
+          github-token: ${{ secrets.GR_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,70 +14,25 @@
 name: release
 
 on:
-  push:
+  release:
+    types:
+      - 'created'
     tags:
       - 'v*'
 
-jobs:
-  unit-tests:
-    name: unit tests 
-    runs-on: ubuntu-latest
-    steps:
-
-    - name: Set up Go 1.14
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.14.7
-      id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: verify license
-      run: make license-check
-
-    - name: verify dependencies
-      run: make deps
-
-    - name: verify tests
-      run: make test
-
-  e2e-tests:
-    needs: ['unit-tests']
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        kubernetes: [v1.18.6]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      
-      - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.3.0
-        with:
-          minikube version: v1.9.2
-          kubernetes version: ${{ matrix.kubernetes }}
-          github token: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Set Tag
-        run: |
-          TAG="${GITHUB_REF#refs/*/v}"
-          echo "TAG=${TAG}" >> $GITHUB_ENV
-          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
-
-      - name: Build images locally
-        run: make all.amd64 || exit 1;
-      
-      - name: Running tests
-        run: ./ci/sanity/install.sh && ./ci/sanity/sanity.sh
-  
+jobs:  
   cspc-operator:
     runs-on: ubuntu-latest
     needs: ['e2e-tests']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
 
       - name: Set Tag
         run: |
@@ -85,8 +40,26 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cspc-operator
+            quay.io/${{ env.IMAGE_ORG }}/cspc-operator
+          tag-latest: true
+          tag-semver: |
+            {{version}}
+
       - name: Print Tag info
         run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
           echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
@@ -106,28 +79,67 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.cspc-operator
-          make buildx.push.cspc-operator
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/cspc-operator/cspc-operator.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
+            DBUILD_SITE_URL=https://openebs.io
+            RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   cvc-operator:
     runs-on: ubuntu-latest
     needs: ['e2e-tests']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
 
       - name: Set Tag
         run: |
           TAG="${GITHUB_REF#refs/*/v}"
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
+      
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cvc-operator
+            quay.io/${{ env.IMAGE_ORG }}/cvc-operator
+          tag-latest: true
+          tag-semver: |
+            {{version}}
 
       - name: Print Tag info
         run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
           echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
@@ -147,19 +159,40 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.cvc-operator
-          make buildx.push.cvc-operator
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/cvc-operator/cvc-operator.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
+            DBUILD_SITE_URL=https://openebs.io
+            RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   pool-manager:
     runs-on: ubuntu-latest
     needs: ['e2e-tests']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
 
       - name: Set Tag
         run: |
@@ -167,8 +200,26 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cstor-pool-manager
+            quay.io/${{ env.IMAGE_ORG }}/cstor-pool-manager
+          tag-latest: true
+          tag-semver: |
+            {{version}}
+
       - name: Print Tag info
         run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
           echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
@@ -188,19 +239,40 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.pool-manager
-          make buildx.push.pool-manager
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/pool-manager/pool-manager.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
+            DBUILD_SITE_URL=https://openebs.io
+            RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   volume-manager:
     runs-on: ubuntu-latest
     needs: ['e2e-tests']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
 
       - name: Set Tag
         run: |
@@ -208,8 +280,26 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cstor-volume-manager
+            quay.io/${{ env.IMAGE_ORG }}/cstor-volume-manager
+          tag-latest: true
+          tag-semver: |
+            {{version}}
+
       - name: Print Tag info
         run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
           echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
@@ -229,19 +319,40 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.volume-manager
-          make buildx.push.volume-manager
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/volume-manager/volume-manager.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
+            DBUILD_SITE_URL=https://openebs.io
+            RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   cstor-webhook:
     runs-on: ubuntu-latest
     needs: ['e2e-tests']
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
+
+      - name: Set Image Org
+        # sets the default IMAGE_ORG to openebs
+        run: |
+          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
+          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
 
       - name: Set Tag
         run: |
@@ -249,8 +360,26 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_ENV
           echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
 
+      - name: Set Build Date
+        id: date
+        run: |
+          echo "::set-output name=DATE::$(date -u +'%Y-%m-%dT%H:%M:%S%Z')"
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          # add each registry to which the image needs to be pushed here
+          images: |
+            ${{ env.IMAGE_ORG }}/cstor-webhook
+            quay.io/${{ env.IMAGE_ORG }}/cstor-webhook
+          tag-latest: true
+          tag-semver: |
+            {{version}}
+
       - name: Print Tag info
         run: |
+          echo "${{ steps.docker_meta.outputs.tags }}"
           echo "RELEASE TAG: ${RELEASE_TAG}"
 
       - name: Set up QEMU
@@ -270,9 +399,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to Quay
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
       - name: Build & Push Image
-        env:
-          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
-        run: |
-          make docker.buildx.cstor-webhook
-          make buildx.push.cstor-webhook
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./build/cstor-webhook/cstor-webhook.Dockerfile
+          push: true
+          platforms: linux/amd64, linux/arm64
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          build-args: |
+            DBUILD_DATE=${{ steps.date.outputs.DATE }}
+            DBUILD_REPO_URL=https://github.com/openebs/cstor-operators
+            DBUILD_SITE_URL=https://openebs.io
+            RELEASE_TAG=${{ env.RELEASE_TAG }}

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ pool-manager-image:
 	@echo "----------------------------"
 	@PNAME=${POOL_MANAGER} CTLNAME=${POOL_MANAGER} sh -c "'$(PWD)/build/build.sh'"
 	@cp bin/${POOL_MANAGER}/${POOL_MANAGER} build/pool-manager/
-	@cd build/${POOL_MANAGER} && sudo docker build -t ${IMAGE_ORG}/${POOL_MANAGER_REPO_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE_AMD64} ${DBUILD_ARGS} . --no-cache
+	@cd build/${POOL_MANAGER} && sudo docker build -t ${IMAGE_ORG}/${POOL_MANAGER_REPO_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE} ${DBUILD_ARGS} . --no-cache
 	@rm build/${POOL_MANAGER}/${POOL_MANAGER}
 
 .PHONY: cstor-webhook-image

--- a/Makefile
+++ b/Makefile
@@ -80,10 +80,10 @@ endif
 export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}
 
 # Specify the name of cstor-base image
-CSTOR_BASE_IMAGE_AMD64= ${IMAGE_ORG}/cstor-base-amd64:${BASE_TAG}
-export CSTOR_BASE_IMAGE_AMD64
+CSTOR_BASE_IMAGE= ${IMAGE_ORG}/cstor-base:${BASE_TAG}
+export CSTOR_BASE_IMAGE
 
-# Specify the name of the docker repo for amd64
+# Specify the name of the docker repo
 CSPC_OPERATOR_REPO_NAME=cspc-operator
 CVC_OPERATOR_REPO_NAME=cvc-operator
 POOL_MANAGER_REPO_NAME=cstor-pool-manager
@@ -123,8 +123,8 @@ cvc-operator:
 	@echo "    "
 	@PNAME=${CVC_OPERATOR} CTLNAME=${CVC_OPERATOR} sh -c "'$(PWD)/build/build.sh'"
 
-.PHONY: cvc-operator-image.amd64
-cvc-operator-image.amd64:
+.PHONY: cvc-operator-image
+cvc-operator-image:
 	@echo -n "--> cvc-operator image <--"
 	@echo "${IMAGE_ORG}/${CVC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
@@ -133,8 +133,8 @@ cvc-operator-image.amd64:
 	@cd build/${CVC_OPERATOR} && sudo docker build -t ${IMAGE_ORG}/${CVC_OPERATOR_REPO_NAME}:${IMAGE_TAG} ${DBUILD_ARGS} .
 	@rm build/${CVC_OPERATOR}/${CVC_OPERATOR}
 
-.PHONY: volume-manager-image.amd64
-volume-manager-image.amd64:
+.PHONY: volume-manager-image
+volume-manager-image:
 	@echo -n "--> volume manager image <--"
 	@echo "${IMAGE_ORG}/${VOLUME_MANAGER_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
@@ -143,8 +143,8 @@ volume-manager-image.amd64:
 	@cd build/${VOLUME_MANAGER} && sudo docker build -t ${IMAGE_ORG}/${VOLUME_MANAGER_REPO_NAME}:${IMAGE_TAG} ${DBUILD_ARGS} .
 	@rm build/${VOLUME_MANAGER}/${VOLUME_MANAGER}
 
-.PHONY: cspc-operator-image.amd64
-cspc-operator-image.amd64:
+.PHONY: cspc-operator-image
+cspc-operator-image:
 	@echo -n "--> cspc-operator image <--"
 	@echo "${IMAGE_ORG}/${CSPC_OPERATOR_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
@@ -153,8 +153,8 @@ cspc-operator-image.amd64:
 	@cd build/${CSPC_OPERATOR} && sudo docker build -t ${IMAGE_ORG}/${CSPC_OPERATOR_REPO_NAME}:${IMAGE_TAG} ${DBUILD_ARGS} .
 	@rm build/${CSPC_OPERATOR}/${CSPC_OPERATOR}
 
-.PHONY: pool-manager-image.amd64
-pool-manager-image.amd64:
+.PHONY: pool-manager-image
+pool-manager-image:
 	@echo -n "--> pool manager image <--"
 	@echo "${IMAGE_ORG}/${POOL_MANAGER_REPO_NAME}:${IMAGE_TAG}"
 	@echo "----------------------------"
@@ -163,8 +163,8 @@ pool-manager-image.amd64:
 	@cd build/${POOL_MANAGER} && sudo docker build -t ${IMAGE_ORG}/${POOL_MANAGER_REPO_NAME}:${IMAGE_TAG} --build-arg BASE_IMAGE=${CSTOR_BASE_IMAGE_AMD64} ${DBUILD_ARGS} . --no-cache
 	@rm build/${POOL_MANAGER}/${POOL_MANAGER}
 
-.PHONY: cstor-webhook-image.amd64
-cstor-webhook-image.amd64:
+.PHONY: cstor-webhook-image
+cstor-webhook-image:
 	@echo "----------------------------"
 	@echo -n "--> cstor-webhook image "
 	@echo "${IMAGE_ORG}/${CSTOR_WEBHOOK_REPO_NAME}:${IMAGE_TAG}"
@@ -174,9 +174,9 @@ cstor-webhook-image.amd64:
 	@cd build/${CSTOR_WEBHOOK} && sudo docker build -t ${IMAGE_ORG}/${CSTOR_WEBHOOK_REPO_NAME}:${IMAGE_TAG} ${DBUILD_ARGS} .
 	@rm build/${CSTOR_WEBHOOK}/${WEBHOOK_REPO}
 
-.PHONY: all.amd64
-all.amd64: cspc-operator-image.amd64 pool-manager-image.amd64 cstor-webhook-image.amd64 \
-           cvc-operator-image.amd64 volume-manager-image.amd64
+.PHONY: all
+all: cspc-operator-image pool-manager-image cstor-webhook-image \
+           cvc-operator-image volume-manager-image
 
 # Push images
 .PHONY: deploy-images

--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -21,8 +21,6 @@
 
 export DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg RELEASE_TAG=${RELEASE_TAG} --build-arg BRANCH=${BRANCH}
 
-CSTOR_BASE_IMAGE= ${IMAGE_ORG}/cstor-base:${BASE_TAG}
-
 ifeq (${TAG}, )
   export TAG=ci
 endif

--- a/pkg/version/util.go
+++ b/pkg/version/util.go
@@ -23,7 +23,7 @@ var (
 		"1.10.0": true, "1.11.0": true, "1.12.0": true,
 		"2.0.0": true, "2.1.0": true, "2.2.0": true, "2.3.0": true,
 		"2.4.0": true, "2.4.1": true, "2.5.0": true, "2.6.0": true, "2.7.0": true,
-		"2.8.0": true,
+		"2.8.0": true, "2.9.0": true,
 	}
 	validDesiredVersion = strings.Split(GetVersion(), "-")[0]
 )


### PR DESCRIPTION
  This PR 
  - replaces the buildx makefile with build and push action for multi repo push
  - add quay.io repo to push images
  - avoid build when release is created

Signed-off-by: shubham <shubham.bajpai@mayadata.io>