### PR TITLE
fix(helm): replace deprecated hyperkube image in pre-delete hook

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.8.0
+version: 2.8.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.8.0

--- a/deploy/helm/charts/templates/cleanup-webhook.yaml
+++ b/deploy/helm/charts/templates/cleanup-webhook.yaml
@@ -1,3 +1,9 @@
+# HELM first deletes RBAC, then it tries to delete other resources like CSPC and PVC. 
+# We've got validating webhook on CSPC and PVC.
+# But even that the policy of this webhook is Ignore, it fails because the ServiceAccount 
+# does not have permission to access resources like BDC anymore which are used for validation.
+# Therefore we first need to delete webhook so we can delete the rest of the deployments.
+{{- $kubeMinor := .Capabilities.KubeVersion.Minor | replace "+" "" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -18,7 +24,9 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.cstorOperator.name }}
       containers:
         - name: kubectl
-          image: "{{ .Values.hyperkubeImage.repository }}:{{ .Values.hyperkubeImage.tag }}"
+          {{- /* bitnami maintains an image for all k8s versions */}}
+          {{- /* see: https://hub.docker.com/r/bitnami/kubectl */}}
+          image: {{ printf "%s/%s:%s.%s" "bitnami" "kubectl" .Capabilities.KubeVersion.Major $kubeMinor }}
           imagePullPolicy: "{{ .Values.hyperkubeImage.pullPolicy }}"
           command:
           - /bin/sh

--- a/deploy/helm/charts/templates/cleanup-webhook.yaml
+++ b/deploy/helm/charts/templates/cleanup-webhook.yaml
@@ -27,7 +27,6 @@ spec:
           {{- /* bitnami maintains an image for all k8s versions */}}
           {{- /* see: https://hub.docker.com/r/bitnami/kubectl */}}
           image: {{ printf "%s/%s:%s.%s" "bitnami" "kubectl" .Capabilities.KubeVersion.Major $kubeMinor }}
-          imagePullPolicy: "{{ .Values.hyperkubeImage.pullPolicy }}"
           command:
           - /bin/sh
           - -c

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -232,10 +232,3 @@ analytics:
   enabled: true
   # Specify in hours the duration after which a ping event needs to be sent.
   pingInterval: "24h"
-
-# this is to cleanup the validatingwebhook after deletion of the charts
-# via a pre-delete webhook job
-hyperkubeImage:
-  repository: "k8s.gcr.io/hyperkube"
-  tag: "v1.12.1"
-  pullPolicy: "IfNotPresent"


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR addresses the issue: https://github.com/openebs/openebs/issues/3383
The solution is based on looking into other projects with similar webhook related problems ref: https://github.com/Kong/gcp-marketplace/blob/main/GKE/Kuma/chart/templates/pre-delete-webhooks.yaml