### PR TITLE
fix(helm chart): rename priority class name for CSI plugin (node and controller)

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.8.1
+version: 2.8.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.8.0

--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -193,3 +193,25 @@ Create labels for cstor csi controller
 {{ include "cstor.csiController.matchLabels" . }}
 {{ include "cstor.csiController.componentLabels" . }}
 {{- end -}}
+
+{{/*
+Create the name of the priority class for csi node plugin
+*/}}
+{{- define "cstor.csiNode.priorityClassName" -}}
+{{- if .Values.csiNode.priorityClass.create }}
+{{- printf "%s-%s" .Release.Name .Values.csiNode.priorityClass.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s" .Values.csiNode.priorityClass.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the priority class for csi controller plugin
+*/}}
+{{- define "cstor.csiController.priorityClassName" -}}
+{{- if .Values.csiController.priorityClass.create }}
+{{- printf "%s-%s" .Release.Name .Values.csiController.priorityClass.name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s" .Values.csiController.priorityClass.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/charts/templates/csi-controller.yaml
+++ b/deploy/helm/charts/templates/csi-controller.yaml
@@ -21,7 +21,7 @@ spec:
         {{ toYaml .Values.csiController.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      priorityClassName: openebs-cstor-csi-controller-critical
+      priorityClassName: {{ template "cstor.csiController.priorityClassName" . }}
       serviceAccount: {{ .Values.serviceAccount.csiController.name }}
       containers:
         - name: {{ .Values.csiController.resizer.name }}

--- a/deploy/helm/charts/templates/csi-controller.yaml
+++ b/deploy/helm/charts/templates/csi-controller.yaml
@@ -21,7 +21,7 @@ spec:
         {{ toYaml .Values.csiController.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      priorityClassName: openebs-csi-controller-critical
+      priorityClassName: openebs-cstor-csi-controller-critical
       serviceAccount: {{ .Values.serviceAccount.csiController.name }}
       containers:
         - name: {{ .Values.csiController.resizer.name }}

--- a/deploy/helm/charts/templates/csi-node.yaml
+++ b/deploy/helm/charts/templates/csi-node.yaml
@@ -19,7 +19,7 @@ spec:
         {{ toYaml .Values.csiNode.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      priorityClassName: openebs-cstor-csi-node-critical
+      priorityClassName: {{ template "cstor.csiNode.priorityClassName" . }}
       serviceAccount: {{ .Values.serviceAccount.csiNode.name }}
       hostNetwork: true
       containers:

--- a/deploy/helm/charts/templates/csi-node.yaml
+++ b/deploy/helm/charts/templates/csi-node.yaml
@@ -19,7 +19,7 @@ spec:
         {{ toYaml .Values.csiNode.podLabels | nindent 8 }}
         {{- end }}
     spec:
-      priorityClassName: openebs-csi-node-critical
+      priorityClassName: openebs-cstor-csi-node-critical
       serviceAccount: {{ .Values.serviceAccount.csiNode.name }}
       hostNetwork: true
       containers:

--- a/deploy/helm/charts/templates/priority-class.yaml
+++ b/deploy/helm/charts/templates/priority-class.yaml
@@ -1,15 +1,19 @@
+{{- if .Values.csiController.priorityClass.create }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-cstor-csi-controller-critical
+  name: {{ template "cstor.csiController.priorityClassName" . }}
 value: 900000000
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver controller deployment only."
+{{- end }}
 ---
+{{- if .Values.csiNode.priorityClass.create }}
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-cstor-csi-node-critical
+  name: {{ template "cstor.csiNode.priorityClassName" . }}
 value: 900001000
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver node deployment only."
+{{- end }}

--- a/deploy/helm/charts/templates/priority-class.yaml
+++ b/deploy/helm/charts/templates/priority-class.yaml
@@ -1,7 +1,7 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-csi-controller-critical
+  name: openebs-cstor-csi-controller-critical
 value: 900000000
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver controller deployment only."
@@ -9,7 +9,7 @@ description: "This priority class should be used for the CStor CSI driver contro
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-csi-node-critical
+  name: openebs-cstor-csi-node-critical
 value: 900001000
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver node deployment only."

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -87,6 +87,9 @@ cvcOperator:
   securityContext: {}
 
 csiController:
+  priorityClass:
+    create: true
+    name: cstor-csi-controller-critical
   componentName: "openebs-cstor-csi-controller"
   resizer:
     name: "csi-resizer"
@@ -159,6 +162,9 @@ cstorCSIPlugin:
   remount: "true"
 
 csiNode:
+  priorityClass:
+    create: true
+    name: cstor-csi-node-critical
   componentName: "openebs-cstor-csi-node"
   driverRegistrar:
     name: "csi-node-driver-registrar"


### PR DESCRIPTION
Include storage engine name in priority class name to make sure CSI driver of different storage will have different priority class. This will resolve the issue of installing multiple storage engine using helm chart.

What will happen to older priority classes(upgrade scenario)?
=> Older priority classes will be deleted and CSI node and controller driver pod will be restarted with new priority classes.