### PR TITLE
Added Gitpod config

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+tasks:
+  - init: make all
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,3 +1,4 @@
+
 tasks:
   - init: make all
 github:
@@ -7,3 +8,8 @@ github:
     pullRequests: true
     pullRequestsFromForks: true
     addCheck: true
+
+vscode:
+  extensions:
+    - golang.go
+    - ms-azuretools.vscode-docker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,7 @@ git clone https://github.com/openebs/cstor-operators
 cd cstor-operators
 make all.amd64
 ```
+
+Alternatively, you can open this repo in Gitpod and mkae your PR right from the browser:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/openebs/cstor-operators)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Go Report](https://goreportcard.com/badge/github.com/openebs/cstor-operators)](https://goreportcard.com/report/github.com/openebs/cstor-operators)
 [![Build Status](https://github.com/openebs/cstor-operators/actions/workflows/build.yml/badge.svg)](https://github.com/openebs/cstor-operators/actions/workflows/build.yml)
 [![Slack](https://img.shields.io/badge/JOIN-SLACK-blue)](https://kubernetes.slack.com/messages/openebs/)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-908a85?logo=gitpod)](https://gitpod.io/#https://github.com/openebs/cstor-operators)
 
 <img width="300" align="right" alt="OpenEBS Logo" src="https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/stacked/color/openebs-stacked-color.png" xmlns="http://www.w3.org/1999/html">
 


### PR DESCRIPTION
Hi OpenEBS team! 👋

here is a PR that fully-automates the dev setup of cstor-operators with Gitpod, providing anyone with a pre-built, browser-based development environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/$project/$repo)

<img width="1377" alt="Screen Shot 2021-05-04 at 16 59 00" src="https://user-images.githubusercontent.com/377752/117024329-30797600-acfa-11eb-9fe8-8a535374f59d.png">

## What it does

* Comes with all dependencies pre-installed (including Go, Docker, etc.)
* Runs `make all` ahead-of-time so you don't need to wait
* Gives anyone immediate access to the pre-compiled cstor-operators CLI, and allows to easily edit & rebuild the code

I hope this can make life easier for contributors, and for maintainers who need to review many PRs (hint: you can already open this PR in Gitpod to easily review & test it without messing up your local checkout).

Please let me know if I should open issues for these & how they can be fixed (e.g. in the generator).

And I'm looking forward to your feedback on this PR! 🚀