### PR TITLE
static check fixes in {controllers, volume-rpc, server/cstorvolumeconfig}

### DIFF
--- a/pkg/controllers/cspc-controller/handler_test.go
+++ b/pkg/controllers/cspc-controller/handler_test.go
@@ -84,11 +84,6 @@ func (f *fixture) expectListCSPIAction(cspc *cstor.CStorPoolCluster) {
 	f.actions = append(f.actions, action)
 }
 
-func (f *fixture) expectGetBDAction(cspc *cstor.CStorPoolCluster, bdName string) {
-	action := core.NewGetAction(schema.GroupVersionResource{Resource: "blockdevices"}, cspc.Namespace, bdName)
-	f.actions = append(f.actions, action)
-}
-
 func (f *fixture) FakeDiskCreator(totalDisk, totalNode int) {
 	// Create some fake block device objects over nodes.
 	var key, diskLabel string

--- a/pkg/controllers/replica-controller/handler_test.go
+++ b/pkg/controllers/replica-controller/handler_test.go
@@ -81,6 +81,9 @@ func TestGetVolumeReplicaResource(t *testing.T) {
 
 		// Get volume replica resource with name
 		cStorVolumeReplicaObtained, err := volumeReplicaController.getVolumeReplicaResource(ut.test.ObjectMeta.Namespace + "/" + ut.test.ObjectMeta.Name)
+		if err != nil {
+			t.Fatalf("Desc:%v, Unable to get resource : %v", desc, ut.test.ObjectMeta.Name)
+		}
 
 		if cStorVolumeReplicaObtained.Name != ut.expectedName {
 			t.Fatalf("Desc:%v, volName mismatch, Expected:%v, Got:%v", desc, ut.expectedName,

--- a/pkg/controllers/replica-controller/runner_test.go
+++ b/pkg/controllers/replica-controller/runner_test.go
@@ -194,25 +194,20 @@ func (r TestRunner) RunCombinedOutput(command string, args ...string) ([]byte, e
 	var cmd *exec.Cmd
 	switch args[0] {
 	case "create":
-		cs = append([]string{"-test.run=TestCreaterProcess", "--"})
+		cs = []string{"-test.run=TestCreaterProcess", "--"}
 		//	cmd.Env = append([]string{"createErr=nil"})
-		break
 	case "import":
 		cs = []string{"-test.run=TestImporterProcess", "--"}
 		cmd.Env = []string{"importErr=nil"}
-		break
 	case "destroy":
 		cs = []string{"-test.run=TestDestroyerProcess", "--"}
 		cmd.Env = []string{"destroyErr=nil"}
-		break
 	case "labelclear":
 		cs = []string{"-test.run=TestLabelClearerProcess", "--"}
 		cmd.Env = []string{"labelClearErr=nil"}
-		break
 	case "status":
 		cs = []string{"-test.run=TestStatusProcess", "--"}
 		cmd.Env = []string{"StatusErr=nil"}
-		break
 	}
 	cs = append(cs, args...)
 	cmd = exec.Command(os.Args[0], cs...)
@@ -226,8 +221,7 @@ func (r TestRunner) RunStdoutPipe(command string, args ...string) ([]byte, error
 	var cmd *exec.Cmd
 	switch args[0] {
 	case "get":
-		cs = append([]string{"-test.run=TestGetterProcess", "--"})
-		break
+		cs = []string{"-test.run=TestGetterProcess", "--"}
 	}
 	cs = append(cs, args...)
 	cmd = exec.Command(os.Args[0], cs...)

--- a/pkg/controllers/volume-mgmt/handler_test.go
+++ b/pkg/controllers/volume-mgmt/handler_test.go
@@ -100,6 +100,9 @@ func TestGetVolumeResource(t *testing.T) {
 		}
 		// Get the created volume resource using name
 		cStorVolumeObtained, err := volumeController.getVolumeResource(ut.test.ObjectMeta.Name)
+		if err != nil {
+			t.Fatalf("Desc:%v, Unable to get resource : %v", desc, ut.test.ObjectMeta.Name)
+		}
 		if string(cStorVolumeObtained.ObjectMeta.UID) != ut.expectedVolumeName {
 			t.Fatalf("Desc:%v, VolumeName mismatch, Expected:%v, Got:%v", desc, ut.expectedVolumeName,
 				string(cStorVolumeObtained.ObjectMeta.UID))

--- a/pkg/server/cstorvolumeconfig/v1alpha1_backup.go
+++ b/pkg/server/cstorvolumeconfig/v1alpha1_backup.go
@@ -202,16 +202,10 @@ func (backupWrapper *v1Alpha1BackupWrapper) createBackupResource() (backupHelper
 
 // isBackupFailed returns true if backup failed
 func isBackupFailed(backup *openebsapis.CStorBackup) bool {
-	if backup.Status == openebsapis.BKPCStorStatusFailed {
-		return true
-	}
-	return false
+	return backup.Status == openebsapis.BKPCStorStatusFailed
 }
 
 // isBackupSucceeded returns true if backup completed successfully
 func isBackupSucceeded(backup *openebsapis.CStorBackup) bool {
-	if backup.Status == openebsapis.BKPCStorStatusDone {
-		return true
-	}
-	return false
+	return backup.Status == openebsapis.BKPCStorStatusDone
 }

--- a/pkg/volume-rpc/client/api_test.go
+++ b/pkg/volume-rpc/client/api_test.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"context"
 	"testing"
 
 	"github.com/openebs/api/v2/pkg/proto"
@@ -50,7 +51,7 @@ func TestRunVolumeSnapCreateCommand(t *testing.T) {
 	var s Server
 	for i, c := range cases {
 		t.Run(i, func(t *testing.T) {
-			resp, obtainedErr := s.RunVolumeSnapCreateCommand(nil, c.test)
+			resp, obtainedErr := s.RunVolumeSnapCreateCommand(context.TODO(), c.test)
 
 			if c.expectedError != obtainedErr {
 				// XXX: this can be written in a more compact way. but keeping it this way
@@ -90,7 +91,7 @@ func TestRunVolumeSnapDeleteCommand(t *testing.T) {
 	var s Server
 	for i, c := range cases {
 		t.Run(i, func(t *testing.T) {
-			resp, obtainedErr := s.RunVolumeSnapDeleteCommand(nil, c.test)
+			resp, obtainedErr := s.RunVolumeSnapDeleteCommand(context.TODO(), c.test)
 
 			if c.expectedError != obtainedErr {
 				// XXX: this can be written in a more compact way. but keeping it this way


### PR DESCRIPTION
Fixes:

- redundant breaks in switch case
- `x = append(y)` -> `x = y`
- unused funcs
- unused `err`
- `context.TODO()` instead of `nil`

- [x] Ran `make test` locally 

Signed-off-by: arcolife <archit.py@gmail.com>