### PR TITLE
chore(build): use ubuntu 18.04 as container base image

### DIFF
--- a/build/volume-manager/Dockerfile
+++ b/build/volume-manager/Dockerfile
@@ -14,7 +14,7 @@
 # cstor-volume-mgmt  releases.
 #
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 RUN apt-get update; exit 0
 RUN apt-get -y install rsyslog
 

--- a/build/volume-manager/volume-manager.Dockerfile
+++ b/build/volume-manager/volume-manager.Dockerfile
@@ -41,7 +41,7 @@ COPY . .
 
 RUN make buildx.volume-manager
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL


### PR DESCRIPTION
According to below document, ubuntu 16.04 has reached
it's EOL- https://wiki.ubuntu.com/Releases

Ref :#openebs/openebs/issues/3386

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>