### PR TITLE
fix(cleanup-job): add OR clause to prevent job from failing

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.10.0
+version: 2.10.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.10.0

--- a/deploy/helm/charts/templates/cleanup-webhook.yaml
+++ b/deploy/helm/charts/templates/cleanup-webhook.yaml
@@ -35,5 +35,5 @@ spec:
           - /bin/sh
           - -c
           - >
-              kubectl delete validatingWebhookConfiguration openebs-cstor-validation-webhook;
+              kubectl delete validatingWebhookConfiguration openebs-cstor-validation-webhook || true;
       restartPolicy: OnFailure


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>

Cleanup job fails if the validatingwebhookconfiguration is deleted beforehand. This stalls helm chart remove. Eventually leads to timeout. Fixed it with a OR clause.