### PR TITLE
fix(actions): skip release workflow on helm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,10 @@ on:
   release:
     types:
       - 'created'
-    tags:
-      - 'v*'
 
 jobs:  
   cspc-operator:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -101,6 +100,7 @@ jobs:
             RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   cvc-operator:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -180,6 +180,7 @@ jobs:
             RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   pool-manager:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -260,6 +261,7 @@ jobs:
             BASE_IMAGE=${{ env.IMAGE_ORG }}/cstor-base:${{ env.RELEASE_TAG }}
 
   volume-manager:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -339,6 +341,7 @@ jobs:
             RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   cstor-webhook:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -418,6 +421,7 @@ jobs:
             RELEASE_TAG=${{ env.RELEASE_TAG }}
 
   downstream-tagging:
+    if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     needs: ['cspc-operator', 'cvc-operator', 'pool-manager', 'volume-manager', 'cstor-webhook']
     steps:


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR addresses the issue where a release workflow is triggered when a helm chart is released. The images pushed have tags with the name of the chart like [`cstor-2.10.1`](https://github.com/openebs/cstor-operators/actions/runs/950098654) in this case. We should avoid building images in such cases. The if condition added in the workflow prevents such workflows from executing.