### PR TITLE
fix(helm): configure version for snapshot api

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.11.0
+version: 2.11.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.11.0

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -238,4 +238,3 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | serviceAccount.csiController.name | string | `"openebs-cstor-csi-controller-sa"` | CSI Controller ServiceAccount name |
 | serviceAccount.csiNode.create | bool | `true` | Enable CSI Node ServiceAccount |
 | serviceAccount.csiNode.name | string | `"openebs-cstor-csi-node-sa"` | CSI Node ServiceAccount name |
-

--- a/deploy/helm/charts/templates/snapshot-class.yaml
+++ b/deploy/helm/charts/templates/snapshot-class.yaml
@@ -1,5 +1,9 @@
 kind: VolumeSnapshotClass
-apiVersion: snapshot.storage.k8s.io/v1
+apiVersion: {{ if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1" -}}
+  snapshot.storage.k8s.io/v1beta1
+{{- else -}}
+  snapshot.storage.k8s.io/v1
+{{- end }}
 metadata:
   name: csi-cstor-snapshotclass
   annotations:


### PR DESCRIPTION
On some managed K8s clusters like OpenShift or GKE that ship with
their own default CSI Drivers, the controllers will end up creating
v1beta1 objects. An issue like the following was noticed when running
cstor charts on GKE 1.19.

```
 unable to recognize "": no matches for kind "VolumeSnapshotClass" in
 version "snapshot.storage.k8s.io/v1"
```

This commit uses the helm `.Capabilities` to check the version available
in the cluster and install the class accordingly. As the `.Capabilities`
might return false when using with template command, v1 is kept for false
(or default) case.

Manually verified on GKE with and without setting the flag as follows:

```
kiran_mova_mayadata_io@kmova-dev:charts$ helm install openebs-cstor . -n openebs --create-namespace --set openebsNDM.enabled =false 

NAME: openebs-cstor
LAST DEPLOYED: Fri Jul 16 16:55:45 2021
NAMESPACE: openebs
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
The OpenEBS cstor has been installed check its status by running:
....
```

Also, verified that v1 version is generated when running `helm template`

Signed-off-by: kmova <kiran.mova@mayadata.io>