### PR TITLE
refactor[e2e-tests]: Updated the e2e test for target network delay

### DIFF
--- a/e2e-tests/chaoslib/openebs/inject_network_delay_tc.yml
+++ b/e2e-tests/chaoslib/openebs/inject_network_delay_tc.yml
@@ -8,11 +8,20 @@
 #      - status : "induce" for adding the network loss rule
 #                 "remove" for deleting the applied rule.
 
+- name: Display the app information passed via the test job
+  debug: 
+    msg: 
+      - "The application info is as follows:"
+      - "Namespace    : {{ operator_namespace }}"
+      - "Label        : {{ containername }}"
+      - "target       : {{ target_pod }}"
+
 - block:
 
     - name: Checking whether tc is already installed
-      shell: kubectl exec -it {{ target_pod }} -n {{ operator_namespace }} --container {{ containername }} 
-        -- bash -c "which tc"
+      shell: >
+         kubectl exec -it {{ target_pod }} -n {{ operator_namespace }} --container {{ containername }} 
+         -- bash -c "which tc"
       register: tc_status 
       ignore_errors: yes 
 
@@ -40,5 +49,3 @@
       register: apt_rc
 
   when: status == "remove"
-
-

--- a/e2e-tests/chaoslib/openebs/inject_packet_loss_tc.yml
+++ b/e2e-tests/chaoslib/openebs/inject_packet_loss_tc.yml
@@ -11,7 +11,8 @@
 - block:
 
     - name: Checking whether tc is already installed
-      shell: kubectl exec -it {{ target_pod }} -n {{ operator_namespace }} --container {{ containername }} 
+      shell: >
+        kubectl exec -it {{ target_pod }} -n {{ operator_namespace }} --container {{ containername }} 
         -- bash -c "which tc"
       register: tc_status 
       ignore_errors: yes 
@@ -40,5 +41,3 @@
       register: apt_rc
 
   when: status == "remove"
-
-

--- a/e2e-tests/experiments/chaos/openebs_target_network_delay/chaosutil.j2
+++ b/e2e-tests/experiments/chaos/openebs_target_network_delay/chaosutil.j2
@@ -1,0 +1,5 @@
+  {% if cri is defined and cri == 'docker' %}
+    chaosutil: openebs/cstor_target_network_delay.yaml
+  {% elif cri is defined and (cri == 'containerd' or cri == 'cri-o') %}
+    chaosutil: openebs/inject_network_delay_tc.yml
+  {% endif %}

--- a/e2e-tests/experiments/chaos/openebs_target_network_delay/test.yml
+++ b/e2e-tests/experiments/chaos/openebs_target_network_delay/test.yml
@@ -22,8 +22,20 @@
              src: data_persistence.j2
              dest: data_persistence.yml
 
+        - name: Identify the chaos util to be invoked 
+          template:
+             src: chaosutil.j2
+             dest: chaosutil.yml
+
         - include_vars:
             file: data_persistence.yml
+
+        - include_vars:
+            file: chaosutil.yml
+
+        - name: Record the chaos util path
+          set_fact: 
+            chaos_util_path: "/e2e-tests/chaoslib/{{ chaosutil }}"
 
         - name: Record the data consistency util path
           set_fact:
@@ -84,7 +96,7 @@
 
         ## STORAGE FAULT INJECTION 
 
-        - include: "/e2e-tests/chaoslib/openebs/cstor_target_network_delay.yaml"
+        - include: "{{ chaos_util_path }}"
           vars:
             app_ns: "{{ namespace }}"
             app_pvc: "{{ pvc }}"
@@ -92,7 +104,7 @@
             chaos_duration: "{{ c_duration }}"
           when: cri == 'docker'
 
-        - include: "/e2e-tests/chaoslib/openebs/inject_network_delay_tc.yml"
+        - include: "{{ chaos_util_path }}"
           vars:
             status: "induce"
             target_pod: "{{ cstor_target_pod.stdout }}"
@@ -101,7 +113,7 @@
           when: 
             - cri == 'cri-o'
 
-        - include: "/e2e-tests/chaoslib/openebs/inject_network_delay_tc.yml"
+        - include: "{{ chaos_util_path }}"
           vars:
             status: "induce"
             target_pod: "{{ cstor_target_pod.stdout }}"
@@ -114,7 +126,7 @@
           wait_for:
             timeout: 10
 
-        - include: "/e2e-tests/chaoslib/openebs/inject_network_delay_tc.yml"
+        - include: "{{ chaos_util_path }}"
           vars:
             status: "remove"
             target_pod: "{{ cstor_target_pod.stdout }}"
@@ -123,7 +135,7 @@
           when: 
             - cri == 'cri-o'  
 
-        - include: "/e2e-tests/chaoslib/openebs/inject_network_delay_tc.yml"
+        - include: "{{ chaos_util_path }}"
           vars:
             status: "remove"
             target_pod: "{{ cstor_target_pod.stdout }}"

--- a/e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml
+++ b/e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml
@@ -216,18 +216,6 @@
                   args:
                     executable: /bin/bash
 
-                - name: Update the volume snapshotclass template with the variables
-                  template:
-                    src: snapshot-class.j2
-                    dest: snapshot-class.yml
-
-                - name: Create volume snapshotclass
-                  shell: kubectl apply -f snapshot-class.yml
-                  args:
-                    executable: /bin/bash
-                  register: result
-                  failed_when: "result.rc != 0"                    
-
               when: lookup('env','ACTION') == "provision"
 
             - block:
@@ -280,7 +268,7 @@
             - release_tag == "master"
 
         - block:
-
+               
             - name: Checking OpenEBS-CSPC-Operator is running
               shell: >
                 kubectl get pods -n {{ operator_ns }}
@@ -372,6 +360,18 @@
               until: "desired_count.stdout == ready_pods.stdout"
               delay: 5
               retries: 50
+
+            - name: Update the volume snapshotclass template with the variables
+              template:
+                src: snapshot-class.j2
+                dest: snapshot-class.yml
+
+            - name: Create volume snapshotclass
+              shell: kubectl apply -f snapshot-class.yml
+              args:
+                executable: /bin/bash
+              register: result
+              failed_when: "result.rc != 0"            
 
           when: lookup('env','ACTION') == "provision"
 

--- a/e2e-tests/experiments/infra-chaos/drain_node/test.yml
+++ b/e2e-tests/experiments/infra-chaos/drain_node/test.yml
@@ -21,7 +21,7 @@
           vars:
             status: 'SOT'
             chaostype: "drain-node"
-            app: "percona"
+            app: ""
 
         ## DISPLAY APP INFORMATION 
  
@@ -132,5 +132,4 @@
           vars:
             status: 'EOT'
             chaostype: "drain-node"
-            app: "percona"
-           
+            app: ""

--- a/e2e-tests/experiments/infra-chaos/taint_node/test.yml
+++ b/e2e-tests/experiments/infra-chaos/taint_node/test.yml
@@ -20,7 +20,7 @@
           vars:
             status: 'SOT'
             chaostype: "taint-node"
-            app: "percona"
+            app: ""
 
         ## DISPLAY APP INFORMATION 
  
@@ -128,4 +128,4 @@
           vars:
             status: 'EOT'
             chaostype: "taint-node"
-            app: "percona" 
+            app: "" 


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

- Updated the e2e test case for target network delay. Included the chaos util to fix the failure in the test cases 

```
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.17 (default, Feb 27 2021, 15:10:58) [GCC 7.5.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected

PLAYBOOK: test.yml *************************************************************
1 plays in ./e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:3
ok: [127.0.0.1]
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:14
included: /e2e-tests/utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /e2e-tests/utils/fcm/create_testname.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /e2e-tests/utils/fcm/create_testname.yml:7
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:17
included: /e2e-tests/utils/fcm/update_e2e_result_resource.yml for 127.0.0.1

TASK [Generate the e2e result CR to reflect SOT (Start of Test)] ***************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:3
changed: [127.0.0.1] => {"changed": true, "checksum": "6479d1a4571a2e81fb779ca5f0bbc12efa68c3bb", "dest": "./e2e-result.yaml", "gid": 0, "group": "root", "md5sum": "90d30499d8442790edede22f62f7a2c4", "mode": "0644", "owner": "root", "size": 424, "src": "/root/.ansible/tmp/ansible-tmp-1626887471.19-39228700971830/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:14
changed: [127.0.0.1] => {"changed": true, "cmd": "cat e2e-result.yaml", "delta": "0:00:00.727407", "end": "2021-07-21 17:11:12.761586", "rc": 0, "start": "2021-07-21 17:11:12.034179", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: e2e.io/v1alpha1\nkind: E2eResult\nmetadata:\n\n  # name of the e2e testcase\n  name: openebs-cstor-operator-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: e2e.io/v1alpha1", "kind: E2eResult", "metadata:", "", "  # name of the e2e testcase", "  name: openebs-cstor-operator-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the e2e result CR] *************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:17
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f e2e-result.yaml", "delta": "0:00:01.267149", "end": "2021-07-21 17:11:14.237881", "failed_when_result": false, "rc": 0, "start": "2021-07-21 17:11:12.970732", "stderr": "", "stderr_lines": [], "stdout": "e2eresult.e2e.io/openebs-cstor-operator-provision created", "stdout_lines": ["e2eresult.e2e.io/openebs-cstor-operator-provision created"]}

TASK [Generate the e2e result CR to reflect EOT (End of Test)] *****************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:38
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the e2e result CR] *************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:41
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Downloading cstor operator yaml for rc tag] ******************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:23
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Downloading cstor operator yaml for rc tag] ******************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:31
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the value for remount feature for volumes] ************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:39
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the value for admission server failure policy] ********************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:46
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy cStor operator] ***************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:54
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovision cStor operator] **********************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:62
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Downloading the cstor operator file from charts] *************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:76
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the value for remount feature for volumes] ************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:86
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the value for admission server failure policy] ********************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:93
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deploy cStor operator] ***************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:101
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovision cStor operator] **********************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:109
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Downloading the csi operator yaml spec from charts] **********************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:123
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "96f8ab5218d542ef23f4d4d64a53146c0f4b0277", "dest": "/e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/csi-operator.yaml", "gid": 0, "group": "root", "md5sum": "35d8ffcea30db74fd19e2d3b0eacfd70", "mode": "0644", "msg": "OK (70402 bytes)", "owner": "root", "size": 70402, "src": "/root/.ansible/tmp/ansible-tmp-1626887475.1-5105562357223/tmpLwC2KP", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/csi-operator.yaml"}

TASK [Downloading openebs cspc-operator.yaml] **********************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:133
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "2f5b8fe6c644f93965f72e90c00d1227117db6dd", "dest": "/e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/cspc-operator.yaml", "gid": 0, "group": "root", "md5sum": "5dd78f1748aaa2f2691f573a94d6d822", "mode": "0644", "msg": "OK (5505 bytes)", "owner": "root", "size": 5505, "src": "/root/.ansible/tmp/ansible-tmp-1626887476.04-248947585760841/tmpUhPOGN", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/cstor-operator.yaml"}

TASK [Downloading rbac for cstor operator] *************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:143
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "b8f447de3e7fdfc5593afcb2f19c2ed210566553", "dest": "/e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/rbac.yaml", "gid": 0, "group": "root", "md5sum": "2a3a2d867c60bfaf3a61b91129d44e72", "mode": "0644", "msg": "OK (3051 bytes)", "owner": "root", "size": 3051, "src": "/root/.ansible/tmp/ansible-tmp-1626887476.77-93301506446450/tmpVwGl2C", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/rbac.yaml"}

TASK [Downloading crd yaml spec for cstor operator] ****************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:153
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "c3c1d407230061c6a1c05260aea0607f97e26541", "dest": "/e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/all_cstor_crds.yaml", "gid": 0, "group": "root", "md5sum": "fbfcc2019fe57978f79424d0e2d1fe0b", "mode": "0644", "msg": "OK (155964 bytes)", "owner": "root", "size": 155964, "src": "/root/.ansible/tmp/ansible-tmp-1626887477.52-57618139952408/tmpOWORPA", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/crds/all_cstor_crds.yaml"}

TASK [Downloading ndm operator spec] *******************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:163
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "checksum_dest": null, "checksum_src": "45fa074b9cbf5f4c8c002a55b1b582a159aaddf0", "dest": "/e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/ndm-operator.yaml", "gid": 0, "group": "root", "md5sum": "1c6177605c30a28e015f22148eb47d31", "mode": "0644", "msg": "OK (25131 bytes)", "owner": "root", "size": 25131, "src": "/root/.ansible/tmp/ansible-tmp-1626887478.32-156847439776100/tmpm1RkmG", "state": "file", "status_code": 200, "uid": 0, "url": "https://raw.githubusercontent.com/openebs/cstor-operators/master/deploy/ndm-operator.yaml"}

TASK [include_tasks] ***********************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:173
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Change the value for remount feature for volumes] ************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:176
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Change the value for admission server failure policy] ********************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:183
changed: [127.0.0.1] => {"changed": true, "msg": "1 replacements made"}

TASK [Applying cspc rbac] ******************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:193
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f rbac.yaml", "delta": "0:00:01.029689", "end": "2021-07-21 17:11:20.835809", "rc": 0, "start": "2021-07-21 17:11:19.806120", "stderr": "", "stderr_lines": [], "stdout": "namespace/openebs created\nserviceaccount/openebs-cstor-operator created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-operator created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-operator created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-migration created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-migration created", "stdout_lines": ["namespace/openebs created", "serviceaccount/openebs-cstor-operator created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-operator created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-operator created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-migration created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-migration created"]}

TASK [Applying cspc crd] *******************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:198
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f all_cstor_crds.yaml", "delta": "0:00:01.273093", "end": "2021-07-21 17:11:22.326333", "rc": 0, "start": "2021-07-21 17:11:21.053240", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/cstorbackups.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/cstorcompletedbackups.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/cstorpoolclusters.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/cstorpoolinstances.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/cstorrestores.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumeconfigs.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumepolicies.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumereplicas.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/cstorvolumes.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/upgradetasks.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/migrationtasks.openebs.io created", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/cstorbackups.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/cstorcompletedbackups.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/cstorpoolclusters.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/cstorpoolinstances.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/cstorrestores.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/cstorvolumeconfigs.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/cstorvolumepolicies.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/cstorvolumereplicas.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/cstorvolumes.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/upgradetasks.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/migrationtasks.openebs.io created"]}

TASK [Deploy CSI Driver] *******************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:203
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f csi-operator.yaml", "delta": "0:00:01.292431", "end": "2021-07-21 17:11:23.833900", "rc": 0, "start": "2021-07-21 17:11:22.541469", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/cstorvolumeattachments.cstor.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io created\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io created\ncustomresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io created\ncsidriver.storage.k8s.io/cstor.csi.openebs.io created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role created\nserviceaccount/openebs-cstor-csi-controller-sa created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding created\npriorityclass.scheduling.k8s.io/openebs-csi-controller-critical created\npriorityclass.scheduling.k8s.io/openebs-csi-node-critical created\nstatefulset.apps/openebs-cstor-csi-controller created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding created\nserviceaccount/openebs-cstor-csi-node-sa created\nclusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role created\nclusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding created\nconfigmap/openebs-cstor-csi-iscsiadm created\ndaemonset.apps/openebs-cstor-csi-node created", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/cstorvolumeattachments.cstor.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotclasses.snapshot.storage.k8s.io created", "customresourcedefinition.apiextensions.k8s.io/volumesnapshotcontents.snapshot.storage.k8s.io created", "customresourcedefinition.apiextensions.k8s.io/volumesnapshots.snapshot.storage.k8s.io created", "csidriver.storage.k8s.io/cstor.csi.openebs.io created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-binding created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-snapshotter-role created", "serviceaccount/openebs-cstor-csi-controller-sa created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-provisioner-binding created", "priorityclass.scheduling.k8s.io/openebs-csi-controller-critical created", "priorityclass.scheduling.k8s.io/openebs-csi-node-critical created", "statefulset.apps/openebs-cstor-csi-controller created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-attacher-binding created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-cluster-registrar-binding created", "serviceaccount/openebs-cstor-csi-node-sa created", "clusterrole.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-role created", "clusterrolebinding.rbac.authorization.k8s.io/openebs-cstor-csi-registrar-binding created", "configmap/openebs-cstor-csi-iscsiadm created", "daemonset.apps/openebs-cstor-csi-node created"]}

TASK [Applying cspc operator] **************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:209
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f cspc-operator.yaml", "delta": "0:00:01.141806", "end": "2021-07-21 17:11:25.206510", "rc": 0, "start": "2021-07-21 17:11:24.064704", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/cspc-operator created\ndeployment.apps/cvc-operator created\nservice/cvc-operator-service created\ndeployment.apps/openebs-cstor-admission-server created", "stdout_lines": ["deployment.apps/cspc-operator created", "deployment.apps/cvc-operator created", "service/cvc-operator-service created", "deployment.apps/openebs-cstor-admission-server created"]}

TASK [Applying ndm operator] ***************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:214
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f ndm-operator.yaml", "delta": "0:00:01.215805", "end": "2021-07-21 17:11:26.637957", "rc": 0, "start": "2021-07-21 17:11:25.422152", "stderr": "", "stderr_lines": [], "stdout": "customresourcedefinition.apiextensions.k8s.io/blockdevices.openebs.io created\ncustomresourcedefinition.apiextensions.k8s.io/blockdeviceclaims.openebs.io created\nnamespace/openebs unchanged\nconfigmap/node-disk-manager-config created\ndaemonset.apps/node-disk-manager created\ndeployment.apps/node-disk-operator created", "stdout_lines": ["customresourcedefinition.apiextensions.k8s.io/blockdevices.openebs.io created", "customresourcedefinition.apiextensions.k8s.io/blockdeviceclaims.openebs.io created", "namespace/openebs unchanged", "configmap/node-disk-manager-config created", "daemonset.apps/node-disk-manager created", "deployment.apps/node-disk-operator created"]}

TASK [Deprovision CSI Driver] **************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:223
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovision cspc operator] ***********************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:230
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovision ndm operator] ************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:236
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovision cspc rbac] ***************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:241
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Deprovision cspc crd] ****************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:247
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Update the volume snapshotclass template with the variables] *************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:253
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete volume snapshotclass] *********************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:258
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking OpenEBS-CSPC-Operator is running] *******************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:272
FAILED - RETRYING: Checking OpenEBS-CSPC-Operator is running (120 retries left).
FAILED - RETRYING: Checking OpenEBS-CSPC-Operator is running (119 retries left).
FAILED - RETRYING: Checking OpenEBS-CSPC-Operator is running (118 retries left).
FAILED - RETRYING: Checking OpenEBS-CSPC-Operator is running (117 retries left).
FAILED - RETRYING: Checking OpenEBS-CSPC-Operator is running (116 retries left).
changed: [127.0.0.1] => {"attempts": 6, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cspc-operator\")].status.phase}'", "delta": "0:00:00.863559", "end": "2021-07-21 17:11:58.611809", "rc": 0, "start": "2021-07-21 17:11:57.748250", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking OpenEBS-CVC-Operator is running] ********************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:281
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"cvc-operator\")].status.phase}'", "delta": "0:00:00.881337", "end": "2021-07-21 17:11:59.722754", "rc": 0, "start": "2021-07-21 17:11:58.841417", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Checking OpenEBS-CVC-Operator is running] ********************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:290
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.app==\"cstor-admission-webhook\")].status.phase}'", "delta": "0:00:00.861068", "end": "2021-07-21 17:12:00.778421", "rc": 0, "start": "2021-07-21 17:11:59.917353", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Restart the ndm daemonset pods] ******************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:299
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl delete pods -n openebs -l name=openebs-ndm", "delta": "0:00:00.815795", "end": "2021-07-21 17:12:01.827231", "rc": 0, "start": "2021-07-21 17:12:01.011436", "stderr": "", "stderr_lines": [], "stdout": "No resources found", "stdout_lines": ["No resources found"]}

TASK [Obtain the desired number of ndm daemonset] ******************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:304
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get daemonset -n openebs -l name=openebs-ndm -o custom-columns=:.status.desiredNumberScheduled --no-headers", "delta": "0:00:00.798372", "end": "2021-07-21 17:12:02.836016", "rc": 0, "start": "2021-07-21 17:12:02.037644", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Verify readily available daemonset is equal to desired count] ************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:312
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get daemonset -n openebs -l name=openebs-ndm -o custom-columns=:.status.numberReady --no-headers", "delta": "0:00:00.805075", "end": "2021-07-21 17:12:03.853838", "rc": 0, "start": "2021-07-21 17:12:03.048763", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}

TASK [Confirm if node-disk-manager is running in all the nodes] ****************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:323
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -o jsonpath='{.items[?(@.metadata.labels.name==\"openebs-ndm\")].status.phase}' | grep Running | wc -w", "delta": "0:00:00.886339", "end": "2021-07-21 17:12:04.950490", "rc": 0, "start": "2021-07-21 17:12:04.064151", "stderr": "", "stderr_lines": [], "stdout": "0", "stdout_lines": ["0"]}

TASK [check if csi-controller pod is running] **********************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:334
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n openebs -l app=openebs-cstor-csi-controller --no-headers -o custom-columns=:status.phase", "delta": "0:00:00.837481", "end": "2021-07-21 17:12:05.999047", "rc": 0, "start": "2021-07-21 17:12:05.161566", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Obtain the desired number of openebs-csi-node pods] **********************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:345
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get ds -n openebs openebs-cstor-csi-node --no-headers -o custom-columns=:status.desiredNumberScheduled", "delta": "0:00:00.812358", "end": "2021-07-21 17:12:07.022005", "rc": 0, "start": "2021-07-21 17:12:06.209647", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Check if the desired count matches the ready pods] ***********************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:353
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get ds -n openebs openebs-cstor-csi-node --no-headers -o custom-columns=:status.numberReady", "delta": "0:00:00.799137", "end": "2021-07-21 17:12:08.025263", "rc": 0, "start": "2021-07-21 17:12:07.226126", "stderr": "", "stderr_lines": [], "stdout": "5", "stdout_lines": ["5"]}

TASK [Update the volume snapshotclass template with the variables] *************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:364
changed: [127.0.0.1] => {"changed": true, "checksum": "6dd0c21162643a6cdbed255c908b41ce0292b276", "dest": "./snapshot-class.yml", "gid": 0, "group": "root", "md5sum": "35c1b7cd77b1b628bb490a3d9fae9176", "mode": "0644", "owner": "root", "size": 245, "src": "/root/.ansible/tmp/ansible-tmp-1626887528.12-233785606915577/source", "state": "file", "uid": 0}

TASK [Create volume snapshotclass] *********************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:369
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f snapshot-class.yml", "delta": "0:00:01.262891", "end": "2021-07-21 17:12:09.828893", "failed_when_result": false, "rc": 0, "start": "2021-07-21 17:12:08.566002", "stderr": "", "stderr_lines": [], "stdout": "volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor created", "stdout_lines": ["volumesnapshotclass.snapshot.storage.k8s.io/csi-cstor created"]}

TASK [Confirm pods has been deleted] *******************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:380
skipping: [127.0.0.1] => (item=cstor-operator)  => {"changed": false, "item": "cstor-operator", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=cvc-operator)  => {"changed": false, "item": "cvc-operator", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=cstor-admission-webhook)  => {"changed": false, "item": "cstor-admission-webhook", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-cstor-csi-controller)  => {"changed": false, "item": "openebs-cstor-csi-controller", "skip_reason": "Conditional result was False"}
skipping: [127.0.0.1] => (item=openebs-cstor-csi-node)  => {"changed": false, "item": "openebs-cstor-csi-node", "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:397
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /e2e-tests/experiments/cstor-operator/cstor-operator-provisioner/test.yml:406
included: /e2e-tests/utils/fcm/update_e2e_result_resource.yml for 127.0.0.1

TASK [Generate the e2e result CR to reflect SOT (Start of Test)] ***************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the e2e result CR] *************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the e2e result CR to reflect EOT (End of Test)] *****************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:27
changed: [127.0.0.1] => {"changed": true, "checksum": "824051a3f43c29d0e0d748906e8b86f1ba8807c8", "dest": "./e2e-result.yaml", "gid": 0, "group": "root", "md5sum": "a248606988967637d703224c4cf21f69", "mode": "0644", "owner": "root", "size": 422, "src": "/root/.ansible/tmp/ansible-tmp-1626887530.29-279260098914279/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "cat e2e-result.yaml", "delta": "0:00:00.687548", "end": "2021-07-21 17:12:12.883839", "rc": 0, "start": "2021-07-21 17:12:12.196291", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: e2e.io/v1alpha1\nkind: E2eResult\nmetadata:\n\n  # name of the e2e testcase\n  name: openebs-cstor-operator-provision \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype:  \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: e2e.io/v1alpha1", "kind: E2eResult", "metadata:", "", "  # name of the e2e testcase", "  name: openebs-cstor-operator-provision ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype:  ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the e2e result CR] *************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:41
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f e2e-result.yaml", "delta": "0:00:01.012558", "end": "2021-07-21 17:12:14.096014", "failed_when_result": false, "rc": 0, "start": "2021-07-21 17:12:13.083456", "stderr": "", "stderr_lines": [], "stdout": "e2eresult.e2e.io/openebs-cstor-operator-provision configured", "stdout_lines": ["e2eresult.e2e.io/openebs-cstor-operator-provision configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=35   changed=30   unreachable=0    failed=0 
```