### PR TITLE
(E2E):Test case to validate the Multiple application request to connect on single cstor volume

### DIFF
--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/README.md
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/README.md
@@ -2,7 +2,7 @@
 
 | Type  | Description                                                  | Storage | K8s Platform      |
 | ----- | ------------------------------------------------------------ | ------- | ----------------- |
-| Chaos | Verify the application status when the multiple application pods tryijng to connect on sinle cstor volume | OpenEBS | on-premise-VMware |
+| Chaos | Verify the application status when the multiple application pods trying to connect on single cstor volume | OpenEBS | on-premise-VMware |
 
 ## Entry-Criteria
 
@@ -61,7 +61,7 @@ Note: To perform admin operatons on vmware, the VM display name in hypervisor sh
 | APP_NAMESPACE    | Namespace in which application pods are deployed             |
 | APP_LABEL        | Unique Labels in `key=value` format of application deployment |
 | APP_PVC          | Name of persistent volume claim used for app's volume mounts |
-| TARGET_NAMESPACE | Namespace where OpenEBS is installed                         |
+| OPERATOR_NS      | Namespace where OpenEBS is installed                         |
 | DATA_PERSISTENCE | Specify the application name against which data consistency has to be ensured. Example: busybox |
 
 ### Chaos

--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/README.md
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/README.md
@@ -1,0 +1,73 @@
+## Experiment Metadata
+
+| Type  | Description                                                  | Storage | K8s Platform      |
+| ----- | ------------------------------------------------------------ | ------- | ----------------- |
+| Chaos | Verify the application status when the multiple application pods tryijng to connect on sinle cstor volume | OpenEBS | on-premise-VMware |
+
+## Entry-Criteria
+
+- Application services are accessible & pods are healthy
+- Application writes are successful
+
+### Procedure
+
+This scenario validates the behaviour of application and cStor persistent volumes in the amidst of multiple applications trying to connect the single cstor volume. steps followed in this test case
+ - Verify the application that needs to perform chaos is in Healthy and Running state.
+ - Dump data on the application to verify data availability post chaos. 
+ - Obtain the application deployment and scale the application deployment.
+ - Checking the Newly scaled pod is in `ContainerCreating` state and it's not mounted on the volume.
+ - PowerOff the node where the application pod is in Running state. And Validated the pod went to `ContainerCreating` state and the scaled pod is in `Running` state.
+ - Power on the node which shutdown during the chaos check the application pod is not login again. Verify the data availability in the application pod.
+ - Checking the status of target pod and CVR's is in healthy state.
+
+Based on the value of env `DATA_PERSISTENCE`, the corresponding data consistency util will be executed. At present, only busybox and percona-mysql are supported. Along with specifying env in the e2e experiment, user needs to pass name for configmap and the data consistency specific parameters required via configmap in the format as follows:
+
+```
+    parameters.yml: |
+      blocksize: 4k
+      blockcount: 1024
+      testfile: difiletest
+```
+
+It is recommended to pass test-name for configmap and mount the corresponding configmap as volume in the e2e pod. The above snippet holds the parameters required for validation data consistency in busybox application.
+
+For percona-mysql, the following parameters are to be injected into configmap.
+
+```
+    parameters.yml: |
+      dbuser: root
+      dbpassword: k8sDem0
+      dbname: tdb
+```
+
+The configmap data will be utilised by e2e experiments as its variables while executing the scenario.
+
+Based on the data provided, e2e checks if the data is consistent after recovering from induced chaos.
+
+ESX password has to updated through k8s secret created. The e2e runner can retrieve the password from secret as environmental variable and utilize it for performing admin operations on the server.
+
+Note: To perform admin operatons on vmware, the VM display name in hypervisor should match its hostname.
+
+## Associated Utils
+
+- `vm_power_operations.yml`,`mysql_data_persistence.yml`,`busybox_data_persistence.yml`
+
+## e2e experiment Environment Variables
+
+### Application
+
+| Parameter        | Description                                                  |
+| ---------------- | ------------------------------------------------------------ |
+| APP_NAMESPACE    | Namespace in which application pods are deployed             |
+| APP_LABEL        | Unique Labels in `key=value` format of application deployment |
+| APP_PVC          | Name of persistent volume claim used for app's volume mounts |
+| TARGET_NAMESPACE | Namespace where OpenEBS is installed                         |
+| DATA_PERSISTENCE | Specify the application name against which data consistency has to be ensured. Example: busybox |
+
+### Chaos
+
+| Parameter    | Description                                                  |
+| ------------ | ------------------------------------------------------------ |
+| PLATFORM     | The platform where k8s cluster is created. Currently, only 'vmware' is supported. |
+| ESX_HOST_IP  | The IP address of ESX server where the virtual machines are hosted. |
+| ESX_PASSWORD | To be passed as configmap data.                              |

--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/chaosutil.j2
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/chaosutil.j2
@@ -1,0 +1,3 @@
+{% if platform is defined and platform == 'vmware' %}
+  chaosutil: e2e-tests/chaoslib/vmware_chaos/vm_power_operations.yml
+{% endif %}

--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/data_availability_check.yml
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/data_availability_check.yml
@@ -1,0 +1,84 @@
+- block:
+
+   - name: Checking application pod is in running state
+     shell: kubectl get pods -n {{ ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ pod_name }}")].status.phase}'
+     register: result
+     until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
+     delay: 2
+     retries: 150
+
+   - name: Get the container status of application.
+     shell: >
+        kubectl get pods -n {{ ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ pod_name }}")].status.containerStatuses[].state}' | grep running
+     args:
+       executable: /bin/bash
+     register: containerStatus
+     until: "'running' in containerStatus.stdout"
+     delay: 2
+     retries: 150
+
+   - name: Check if db is ready for connections
+     shell: kubectl logs {{ pod_name }} -n {{ ns }} | grep 'ready for connections'
+     register: initcheck
+     until: "'ready for connections' in initcheck.stdout"
+     delay: 5
+     retries: 180
+
+   - name: Checking for the Corrupted tables
+     shell: >
+       kubectl exec {{ pod_name }} -n {{ ns }}
+       -- mysqlcheck -c {{ dbname }} -u{{ dbuser }} -p{{ dbpassword }}
+     args:
+       executable: /bin/bash
+     register: status 
+     failed_when: "'OK' not in status.stdout"
+
+   - name: Verify mysql data persistence 
+     shell: >
+           kubectl exec {{ pod_name }} -n {{ ns }}
+           -- mysql -u{{ dbuser }} -p{{ dbpassword }} -e 'select * from ttbl' {{ dbname }};
+     args:
+       executable: /bin/bash
+     register: result 
+     failed_when: "'tdata' not in result.stdout"   
+
+  when: data_persistence == "mysql"
+
+- block:
+
+   - name: Checking application pod is in running state
+     shell: kubectl get pods -n {{ ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ pod_name }}")].status.phase}'
+     register: result
+     until: "((result.stdout.split()|unique)|length) == 1 and 'Running' in result.stdout"
+     delay: 2
+     retries: 150
+
+   - name: Get the container status of application.
+     shell: >
+        kubectl get pods -n {{ ns }} -o jsonpath='{.items[?(@.metadata.name=="{{ pod_name }}")].status.containerStatuses[].state}' | grep running
+     args:
+       executable: /bin/bash
+     register: containerStatus
+     until: "'running' in containerStatus.stdout"
+     delay: 2
+     retries: 150
+
+   - name: Check the md5sum of stored data file
+     shell: >
+       kubectl exec {{ pod_name }} -n {{ ns }}
+       -- sh -c "md5sum /busybox/{{ testfile }} > /busybox/{{ testfile }}-post-chaos-md5"
+     args:
+       executable: /bin/bash
+     register: status 
+     failed_when: "status.rc != 0"
+
+   - name: Verify whether data is consistent
+     shell: >
+           kubectl exec {{ pod_name }} -n {{ ns }}
+           -- sh -c "diff /busybox/{{ testfile }}-pre-chaos-md5 /busybox/{{ testfile }}-post-chaos-md5"
+     args:
+       executable: /bin/bash
+     register: result 
+     failed_when: "result.rc != 0 or result.stdout != ''"   
+
+  when: data_persistence == "busybox"  

--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/data_persistence.j2
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/data_persistence.j2
@@ -1,0 +1,5 @@
+{% if data_persistence is defined and data_persistence == 'mysql' %}
+   consistencyutil: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml
+  {% elif data_persistence is defined and data_persistence == 'busybox' %}
+   consistencyutil: /e2e-tests/utils/scm/applications/busybox/busybox_data_persistence.yml
+{% endif %}

--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/run_e2e_test.yml
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/run_e2e_test.yml
@@ -1,0 +1,109 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: multiple-app-single-volume
+  namespace: e2e
+data:
+  parameters.yml: |
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: host-password
+  namespace: e2e
+type: Opaque
+data:
+  password:
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: node-password
+  namespace: e2e
+type: Opaque
+data:
+  passwordNode:
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: multiple-application-request-
+  namespace: e2e
+spec:
+  template:
+    metadata:
+      labels:
+        name: multiple-app
+    spec:
+      serviceAccountName: e2e
+      restartPolicy: Never
+      #nodeSelector:
+      #  kubernetes.io/hostname:
+
+      tolerations:
+      - key: "infra-aid"
+        operator: "Equal"
+        value: "observer"
+        effect: "NoSchedule"
+
+      containers:
+      - name: ansibletest
+        image: openebs/cstor-csi-e2e:ci
+        imagePullPolicy: IfNotPresent
+        env:
+
+          - name: ANSIBLE_STDOUT_CALLBACK
+            value: default
+
+          - name: APP_NAMESPACE
+            value: ""
+
+          - name: APP_LABEL
+            value: ""
+
+          - name: APP_PVC
+            value: ""
+            
+          # The platform where k8s cluster is created.
+          - name: PLATFORM
+            value: "vmware"
+
+          # The IP address of ESX HOST
+          - name: ESX_HOST_IP
+            value: ""
+
+          - name: OPERATOR_NS
+            value: openebs
+
+          - name: ESX_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: host-password 
+                key: password
+
+          - name: NODE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: node-password
+                key: passwordNode
+
+          - name: USERNAME
+            value: ''
+
+          # Application name to pick the relevant data persistence check util
+          - name: DATA_PERSISTENCE
+            value: "" 
+
+        command: ["/bin/bash"]
+        args: ["-c", "ANSIBLE_LOCAL_TEMP=$HOME/.ansible/tmp ANSIBLE_REMOTE_TEMP=$HOME/.ansible/tmp ansible-playbook ./e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test.yml -i /etc/ansible/hosts -vv; exit 0"]
+        volumeMounts:
+        - name: parameters
+          mountPath: /mnt/
+      volumes:
+        - name: parameters
+          configMap:
+            name: multiple-app-single-volume

--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test.yml
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test.yml
@@ -1,0 +1,277 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: False
+
+  vars_files:
+    - test_vars.yml
+    - /mnt/parameters.yml
+
+  tasks:
+
+    - block:
+
+        - include_tasks: /e2e-tests/utils/fcm/create_testname.yml
+
+        - include_tasks: /e2e-tests/utils/fcm/update_e2e_result_resource.yml
+          vars:
+            status: 'SOT'
+            chaostype: "node-failure"
+            app: ""
+
+        ## DISPLAY APP INFORMATION
+        - name: Display the app information passed via the test job
+          debug:
+            msg:
+              - "The application info is as follows:"
+              - "Namespace    : {{ namespace }}"
+              - "Label        : {{ label }}"
+
+        - name: Identify the chaos util to be invoked
+          template:
+            src: chaosutil.j2
+            dest: chaosutil.yml
+
+        - include_vars:
+            file: chaosutil.yml
+
+        - name: Record the chaos util path
+          set_fact:
+            chaos_util_path: "/{{ chaosutil }}"
+
+        - name: Identify the data consistency util to be invoked
+          template:
+            src: data_persistence.j2
+            dest: data_persistence.yml
+
+        - include_vars:
+            file: data_persistence.yml
+
+        - name: Record the data consistency util path
+          set_fact:
+            data_consistency_util_path: "{{ consistencyutil }}"
+          when: data_persistence != ''
+
+        ## Verify the APPLICATION UNDER TEST PRE CHAOS
+        - name: Verify if the application is running.
+          include_tasks: /e2e-tests/utils/k8s/status_app_pod.yml
+          vars:
+            app_ns: "{{ namespace }}"
+            app_lkey: "{{ label.split('=')[0] }}"
+            app_lvalue: "{{ label.split('=')[1] }}"
+            delay: '2'
+            retries: '60'
+
+        - name: Get the deployment name
+          shell: >
+            kubectl get deploy -n {{ namespace }} -l {{ label }} --no-headers -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_deploy_name
+
+        ## Fetch application pod name
+        - name: Get application pod name
+          shell: >
+            kubectl get pod -n {{ namespace }} -l {{ label }} --no-headers -o=custom-columns=NAME:".metadata.name"
+          args:
+            executable: /bin/bash
+          register: app_pod_name
+
+        - name: Record the application pod name
+          set_fact:
+            application_pod: "{{ app_pod_name.stdout }}"
+
+        - name: Obtain PVC name from the application mount
+          shell: >
+            kubectl get pods "{{ app_pod_name.stdout }}" -n "{{ namespace }}"
+            -o custom-columns=:.spec.volumes[*].persistentVolumeClaim.claimName --no-headers
+          args:
+            executable: /bin/bash
+          register: pvc
+
+        ## Obtain the node where application pod is running
+        - name: Get Running Application pod Node to perform chaos
+          shell: >
+            kubectl get pod {{ app_pod_name.stdout }} -n {{ namespace }}
+            --no-headers -o custom-columns=:spec.nodeName
+          args:
+            executable: /bin/bash
+          register: app_node
+
+        - name: Record the application pod node name
+          set_fact:
+            app_node_name: "{{ app_node.stdout }}"
+
+        - name: Obtain the Persistent Volume name
+          shell: >
+            kubectl get pvc "{{ pvc.stdout }}" -n "{{ namespace }}" --no-headers
+            -o custom-columns=:.spec.volumeName
+          args:
+            executable: /bin/bash
+          register: pv
+          failed_when: 'pv.stdout == ""'
+
+        - name: Record the pv name
+          set_fact:
+            pv_name: "{{ pv.stdout }}"
+
+        ## Generate data on the application
+        - name: Generate data on the specified application.
+          include: "{{ data_consistency_util_path }}"
+          vars:
+            status: 'LOAD'
+            ns: "{{ namespace }}"
+            pod_name: "{{ app_pod_name.stdout }}"
+          when: data_persistence != ''
+
+        - name: Get the deployment name
+          shell: >
+            kubectl scale deploy -n {{ namespace }} "{{ app_deploy_name.stdout }}" --replicas=2
+          args:
+            executable: /bin/bash
+          register: scale_deploy
+          failed_when: scale_deploy.rc != 0
+
+        - name: Obtaine the newly scaled application pod name
+          shell: >
+            kubectl get pod -n {{ namespace }} -l {{ label }}
+            --no-headers -o=custom-columns=NAME:".metadata.name" | grep -v "{{ app_pod_name.stdout }}"
+          args:
+            executable: /bin/bash
+          register: scaled_pod_name
+
+        - name: check the newly scaled application pod status
+          shell: >
+             kubectl get pod -n {{ namespace }} {{ scaled_pod_name.stdout }}
+             --no-headers -o custom-columns=:.status.containerStatuses[*].state.waiting.reason
+          args:
+            executable: /bin/bash
+          register: scaled_pod_status
+          until: "'ContainerCreating' in scaled_pod_status.stdout"
+          delay: 5
+          retries: 10
+          ignore_errors: true
+
+        - name: Obtain the error message from the scaled app pod
+          shell: >
+             kubectl describe pod
+             -n {{ namespace }} {{ scaled_pod_name.stdout }} | grep "Volume {{ pv_name }} still mounted on node {{ app_node_name }}"
+          args:
+            executable: /bin/bash
+          register: error_status
+          until: "'Volume {{ pv_name }} still mounted on node {{ app_node_name }}' in error_status.stdout"
+          delay: 5
+          retries: 10
+          ignore_errors: true
+
+        ## Execute the chaos util to turn off the target node
+        - include_tasks: "{{ chaos_util_path }}"
+          vars:
+            esx_ip: "{{ host_ip }}"
+            target_node: "{{ app_node.stdout }}"
+            operation: "off"
+          when: platform == 'vmware'
+
+        - name: Check the node status
+          shell: kubectl get nodes {{ app_node.stdout }} --no-headers
+          args:
+            executable: /bin/bash
+          register: state
+          until: "'NotReady' in state.stdout"
+          delay: 15
+          retries: 30
+
+        # wait 5 minutes
+        - name: Wait for the application pod to get evicted
+          wait_for:
+            timeout: 300
+
+        - name: check the application pod event after scale down
+          shell: >
+             kubectl describe pod -n {{ namespace }} {{ app_pod_name.stdout }} | grep "Node is not ready"
+          args:
+            executable: /bin/bash
+          register: pod_event
+          until: "'Node is not ready' in pod_event.stdout"
+          delay: 5
+          retries: 10
+          ignore_errors: true
+
+       ## Application verification after injecting chaos
+        - name: check the application status
+          shell: kubectl get pods -n {{ namespace }} {{ scaled_pod_name.stdout }} --no-headers -o custom-columns=:.status.phase
+          args:
+            executable: /bin/bash
+          register: app_status
+          until: "'Running' in app_status.stdout"
+          delay: 5
+          retries: 10
+          ignore_errors: true
+
+        - name: Check if the CVRs are in healthy state
+          shell: >
+            kubectl get cvr -n {{ operator_ns }} -l openebs.io/persistent-volume={{ pv.stdout }}
+            -o custom-columns=:.status.phase --no-headers
+          args:
+            executable: /bin/bash
+          register: cvr_status
+          until: "((cvr_status.stdout_lines|unique)|length) == 1 and 'Healthy' in cvr_status.stdout"
+          retries: 60
+          delay: 10
+
+        # Turn on the k8s node
+        - include_tasks: "{{ chaos_util_path }}"
+          vars:
+            esx_ip: "{{ host_ip }}"
+            target_node: "{{ app_node.stdout }}"
+            operation: "on"
+          when:
+          - platform == 'vmware'
+
+        ## Obtain the node where application pod is running
+        - name: Get Running Application pod Node
+          shell: >
+            kubectl get pod {{ scaled_pod_name.stdout }} -n {{ namespace }}
+            --no-headers -o custom-columns=:spec.nodeName
+          args:
+            executable: /bin/bash
+          register: scaled_app_node
+
+        - name: Record the application pod node name
+          set_fact:
+            scaled_app_node_name: "{{ scaled_app_node.stdout }}"
+
+        - name: Obtain the error message from the scaled app pod
+          shell: >
+             kubectl describe pod
+             -n {{ namespace }} {{ app_pod_name.stdout }} | grep "Volume {{ pv_name }} still mounted on node {{ scaled_app_node_name }}"
+          args:
+            executable: /bin/bash
+          register: error_status
+          until: "'Volume {{ pv_name }} still mounted on node {{ scaled_app_node_name }}' in error_status.stdout"
+          delay: 5
+          retries: 10
+          ignore_errors: true
+
+        - name: Verify application data persistence
+          include: "data_availability_check.yml"
+          vars:
+            ns: "{{ namespace }}"
+            pod_name: "{{ scaled_pod_name.stdout }}"
+          when: data_persistence != ''
+
+        - set_fact:
+            flag: "Pass"
+
+      rescue:
+              
+        - set_fact:
+            flag: "Fail"
+
+      always:
+          
+        - include_tasks: /e2e-tests/utils/fcm/update_e2e_result_resource.yml
+          vars:
+            status: 'EOT'
+            chaostype: "node-failure"
+            app: ""

--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test.yml
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test.yml
@@ -16,7 +16,7 @@
         - include_tasks: /e2e-tests/utils/fcm/update_e2e_result_resource.yml
           vars:
             status: 'SOT'
-            chaostype: "node-failure"
+            chaostype: "multiple-app-on-single-volume"
             app: ""
 
         ## DISPLAY APP INFORMATION
@@ -124,7 +124,7 @@
             pod_name: "{{ app_pod_name.stdout }}"
           when: data_persistence != ''
 
-        - name: Get the deployment name
+        - name: Scale the application deployment
           shell: >
             kubectl scale deploy -n {{ namespace }} "{{ app_deploy_name.stdout }}" --replicas=2
           args:
@@ -186,7 +186,7 @@
           wait_for:
             timeout: 300
 
-        - name: check the application pod event after scale down
+        - name: check the application pod event after poweroff the node
           shell: >
              kubectl describe pod -n {{ namespace }} {{ app_pod_name.stdout }} | grep "Node is not ready"
           args:
@@ -198,7 +198,7 @@
           ignore_errors: true
 
        ## Application verification after injecting chaos
-        - name: check the application status
+        - name: check the scaled application pod status
           shell: kubectl get pods -n {{ namespace }} {{ scaled_pod_name.stdout }} --no-headers -o custom-columns=:.status.phase
           args:
             executable: /bin/bash
@@ -241,7 +241,7 @@
           set_fact:
             scaled_app_node_name: "{{ scaled_app_node.stdout }}"
 
-        - name: Obtain the error message from the scaled app pod
+        - name: Obtain the error message from the old app pod on old node
           shell: >
              kubectl describe pod
              -n {{ namespace }} {{ app_pod_name.stdout }} | grep "Volume {{ pv_name }} still mounted on node {{ scaled_app_node_name }}"
@@ -273,5 +273,5 @@
         - include_tasks: /e2e-tests/utils/fcm/update_e2e_result_resource.yml
           vars:
             status: 'EOT'
-            chaostype: "node-failure"
+            chaostype: "multiple-app-on-single-volume"
             app: ""

--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test_vars.yml
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test_vars.yml
@@ -1,0 +1,25 @@
+---
+# Test specific parameters
+
+test_name: multiple_application_on_single_volume
+
+namespace: "{{ lookup('env','APP_NAMESPACE') }}"
+
+pvc: "{{ lookup('env','APP_PVC') }}"
+
+label: "{{ lookup('env','APP_LABEL') }}"
+
+platform: "{{ lookup('env','PLATFORM') }}"
+
+host_ip: "{{ lookup('env','ESX_HOST_IP') }}"
+
+esx_pwd: "{{ lookup('env','ESX_PASSWORD') }}"
+
+data_persistence: "{{ lookup('env','DATA_PERSISTENCE') }}"
+
+operator_ns: "{{ lookup('env','OPERATOR_NS') }}"
+
+user: "{{ lookup('env','USERNAME') }}"
+
+node_pwd: "{{ lookup('env','NODE_PASSWORD') }}"
+


### PR DESCRIPTION
Signed-off-by: nsathyaseelan <sathyaseelan.n@mayadata.io>

 - Verify the application that needs to perform chaos in Healthy and Running state.
 - Dump data on the application to verify data availability post chaos. 
 - Obtain the application deployment and scale the application deployment.
 - Checking the Newly scaled pod is in `ContainerCreating` state and it's not mounted on the volume. And validated the Exsisting application pod status is Running. i.e: only one application pod should be running at a time
 - PowerOff the node where the application pod is in Running state. And Validated the pod went to `ContainerCreating` state and the scaled pod is in `Running` state.
 - Power on the node which shutdown during the chaos check the application pod is not login again. Verify the data availability in the application pod.
 - Checking the status of target pod and CVR's is in healthy state.
 
 Test Case log:
 
 ```
 d2iq@rack2:~/sathya/cstor-operators/e2e-tests$ kubectl logs -f multiple-deployment-request-vq6j8-lkd65 -n e2e
ansible-playbook 2.7.3
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.17 (default, Feb 27 2021, 15:10:58) [GCC 7.5.0]
No config file found; using defaults
/etc/ansible/hosts did not meet host_list requirements, check plugin documentation if this is unexpected
/etc/ansible/hosts did not meet script requirements, check plugin documentation if this is unexpected
statically imported: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml

PLAYBOOK: test.yml *************************************************************
1 plays in ./e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml

PLAY [localhost] ***************************************************************
META: ran handlers

TASK [include_tasks] ***********************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:14
included: /e2e-tests/utils/fcm/create_testname.yml for 127.0.0.1

TASK [Record test instance/run ID] *********************************************
task path: /e2e-tests/utils/fcm/create_testname.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Construct testname appended with runID] **********************************
task path: /e2e-tests/utils/fcm/create_testname.yml:7
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [include_tasks] ***********************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:16
included: /e2e-tests/utils/fcm/update_e2e_result_resource.yml for 127.0.0.1

TASK [Generate the e2e result CR to reflect SOT (Start of Test)] ***************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:3
changed: [127.0.0.1] => {"changed": true, "checksum": "5a40dd3938d22e740e684a32ab530d038ddedd1a", "dest": "./e2e-result.yaml", "gid": 0, "group": "root", "md5sum": "805ed0203391f9a0678340a9575bfe13", "mode": "0644", "owner": "root", "size": 416, "src": "/root/.ansible/tmp/ansible-tmp-1627377021.65-55659909707721/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:14
changed: [127.0.0.1] => {"changed": true, "cmd": "cat e2e-result.yaml", "delta": "0:00:00.694351", "end": "2021-07-27 09:10:23.120894", "rc": 0, "start": "2021-07-27 09:10:22.426543", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: e2e.io/v1alpha1\nkind: E2eResult\nmetadata:\n\n  # name of the e2e testcase\n  name: node-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: node-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: in-progress  \n    result: none ", "stdout_lines": ["---", "apiVersion: e2e.io/v1alpha1", "kind: E2eResult", "metadata:", "", "  # name of the e2e testcase", "  name: node-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: node-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: in-progress  ", "    result: none "]}

TASK [Apply the e2e result CR] *************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:17
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f e2e-result.yaml", "delta": "0:00:01.189664", "end": "2021-07-27 09:10:24.487820", "failed_when_result": false, "rc": 0, "start": "2021-07-27 09:10:23.298156", "stderr": "", "stderr_lines": [], "stdout": "e2eresult.e2e.io/node-failure created", "stdout_lines": ["e2eresult.e2e.io/node-failure created"]}

TASK [Generate the e2e result CR to reflect EOT (End of Test)] *****************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:38
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the e2e result CR] *************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:41
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Display the app information passed via the test job] *********************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:23
ok: [127.0.0.1] => {
    "msg": [
        "The application info is as follows:", 
        "Namespace    : app-percona-ns", 
        "Label        : name=percona"
    ]
}

TASK [Identify the chaos util to be invoked] ***********************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:30
changed: [127.0.0.1] => {"changed": true, "checksum": "1e96d1ef9da25f39ad2f4f5761fc91658cef1679", "dest": "./chaosutil.yml", "gid": 0, "group": "root", "md5sum": "9f3676b887bb8fa66f6a5fea2b09e8ab", "mode": "0644", "owner": "root", "size": 69, "src": "/root/.ansible/tmp/ansible-tmp-1627377024.72-158486522937455/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:35
ok: [127.0.0.1] => {"ansible_facts": {"chaosutil": "e2e-tests/chaoslib/vmware_chaos/vm_power_operations.yml"}, "ansible_included_var_files": ["/e2e-tests/experiments/infra-chaos/multiple_deployment/chaosutil.yml"], "changed": false}

TASK [Record the chaos util path] **********************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:38
ok: [127.0.0.1] => {"ansible_facts": {"chaos_util_path": "/e2e-tests/chaoslib/vmware_chaos/vm_power_operations.yml"}, "changed": false}

TASK [Identify the data consistency util to be invoked] ************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:42
changed: [127.0.0.1] => {"changed": true, "checksum": "6aff72c5b2576007d070ed0b3daa5f48a630986d", "dest": "./data_persistence.yml", "gid": 0, "group": "root", "md5sum": "cf96b7099f461f5c7dea39ce3e9448ed", "mode": "0644", "owner": "root", "size": 90, "src": "/root/.ansible/tmp/ansible-tmp-1627377025.06-116347623388071/source", "state": "file", "uid": 0}

TASK [include_vars] ************************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:47
ok: [127.0.0.1] => {"ansible_facts": {"consistencyutil": "/e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "ansible_included_var_files": ["/e2e-tests/experiments/infra-chaos/multiple_deployment/data_persistence.yml"], "changed": false}

TASK [Record the data consistency util path] ***********************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:50
ok: [127.0.0.1] => {"ansible_facts": {"data_consistency_util_path": "/e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml"}, "changed": false}

TASK [Verify if the application is running.] ***********************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:56
included: /e2e-tests/utils/k8s/status_app_pod.yml for 127.0.0.1

TASK [Get the container status of application.] ********************************
task path: /e2e-tests/utils/k8s/status_app_pod.yml:2
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=\"percona\" -o custom-columns=:..containerStatuses[].state --no-headers | grep -w \"running\"", "delta": "0:00:00.819905", "end": "2021-07-27 09:10:26.388531", "rc": 0, "start": "2021-07-27 09:10:25.568626", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2021-07-27T09:01:24Z]]", "stdout_lines": ["map[running:map[startedAt:2021-07-27T09:01:24Z]]"]}

TASK [Checking {{ application_name }} pod is in running state] *****************
task path: /e2e-tests/utils/k8s/status_app_pod.yml:13
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.labels.name==\"percona\")].status.phase}'", "delta": "0:00:00.778849", "end": "2021-07-27 09:10:27.359004", "rc": 0, "start": "2021-07-27 09:10:26.580155", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the deployment name] *************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:65
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get deploy -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.797704", "end": "2021-07-27 09:10:28.344369", "rc": 0, "start": "2021-07-27 09:10:27.546665", "stderr": "", "stderr_lines": [], "stdout": "percona", "stdout_lines": ["percona"]}

TASK [Get application pod name] ************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:73
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\"", "delta": "0:00:00.826206", "end": "2021-07-27 09:10:29.340102", "rc": 0, "start": "2021-07-27 09:10:28.513896", "stderr": "", "stderr_lines": [], "stdout": "percona-64895d9496-9gv8t", "stdout_lines": ["percona-64895d9496-9gv8t"]}

TASK [Record the application pod name] *****************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:80
ok: [127.0.0.1] => {"ansible_facts": {"application_pod": "percona-64895d9496-9gv8t"}, "changed": false}

TASK [Obtain PVC name from the application mount] ******************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:84
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pods \"percona-64895d9496-9gv8t\" -n \"app-percona-ns\" -o custom-columns=:.spec.volumes[*].persistentVolumeClaim.claimName --no-headers", "delta": "0:00:00.814714", "end": "2021-07-27 09:10:30.369530", "rc": 0, "start": "2021-07-27 09:10:29.554816", "stderr": "", "stderr_lines": [], "stdout": "percona-mysql-claim", "stdout_lines": ["percona-mysql-claim"]}

TASK [Get Running Application pod Node to perform chaos] ***********************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:93
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-64895d9496-9gv8t -n app-percona-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.836145", "end": "2021-07-27 09:10:31.383737", "rc": 0, "start": "2021-07-27 09:10:30.547592", "stderr": "", "stderr_lines": [], "stdout": "d2iq-node2", "stdout_lines": ["d2iq-node2"]}

TASK [Record the application pod node name] ************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:101
ok: [127.0.0.1] => {"ansible_facts": {"app_node_name": "d2iq-node2"}, "changed": false}

TASK [Obtain the Persistent Volume name] ***************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:105
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pvc \"percona-mysql-claim\" -n \"app-percona-ns\" --no-headers -o custom-columns=:.spec.volumeName", "delta": "0:00:00.787126", "end": "2021-07-27 09:10:32.392434", "failed_when_result": false, "rc": 0, "start": "2021-07-27 09:10:31.605308", "stderr": "", "stderr_lines": [], "stdout": "pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2", "stdout_lines": ["pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2"]}

TASK [Record the pv name] ******************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:114
ok: [127.0.0.1] => {"ansible_facts": {"pv_name": "pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2"}, "changed": false}

TASK [Generate data on the specified application.] *****************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:119
included: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml for 127.0.0.1

TASK [Create some test data in the mysql database] *****************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:4
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create database tdb;') => {"changed": true, "cmd": "kubectl exec percona-64895d9496-9gv8t -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create database tdb;'", "delta": "0:00:00.935312", "end": "2021-07-27 09:10:33.654354", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create database tdb;'", "rc": 0, "start": "2021-07-27 09:10:32.719042", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb) => {"changed": true, "cmd": "kubectl exec percona-64895d9496-9gv8t -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "delta": "0:00:00.988904", "end": "2021-07-27 09:10:34.792581", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'create table ttbl (Data VARCHAR(20));' tdb", "rc": 0, "start": "2021-07-27 09:10:33.803677", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}
changed: [127.0.0.1] => (item=mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES ("tdata");' tdb) => {"changed": true, "cmd": "kubectl exec percona-64895d9496-9gv8t -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "delta": "0:00:00.895353", "end": "2021-07-27 09:10:35.848353", "failed_when_result": false, "item": "mysql -uroot -pk8sDem0 -e 'insert into ttbl (Data) VALUES (\"tdata\");' tdb", "rc": 0, "start": "2021-07-27 09:10:34.953000", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "", "stdout_lines": []}

TASK [Kill the application pod] ************************************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:21
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify if the application pod is deleted] ********************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:27
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Obtain the newly created pod name for application] ***********************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:37
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking application pod is in running state] ****************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:44
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:51
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check if db is ready for connections] ************************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:61
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Checking for the Corrupted tables] ***************************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:68
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify mysql data persistence] *******************************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:77
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Delete/drop MySQL database] **********************************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:90
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify successful db delete] *********************************************
task path: /e2e-tests/utils/scm/applications/mysql/mysql_data_persistence.yml:98
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the deployment name] *************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:127
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl scale deploy -n app-percona-ns \"percona\" --replicas=2", "delta": "0:00:00.851483", "end": "2021-07-27 09:10:37.213556", "failed_when_result": false, "rc": 0, "start": "2021-07-27 09:10:36.362073", "stderr": "", "stderr_lines": [], "stdout": "deployment.apps/percona scaled", "stdout_lines": ["deployment.apps/percona scaled"]}

TASK [Obtaine the newly scaled application pod name] ***************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:135
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod -n app-percona-ns -l name=percona --no-headers -o=custom-columns=NAME:\".metadata.name\" | grep -v \"percona-64895d9496-9gv8t\"", "delta": "0:00:00.799851", "end": "2021-07-27 09:10:38.200392", "rc": 0, "start": "2021-07-27 09:10:37.400541", "stderr": "", "stderr_lines": [], "stdout": "percona-64895d9496-t5jdh", "stdout_lines": ["percona-64895d9496-t5jdh"]}

TASK [check the newly scaled application pod status] ***************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:143
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pod -n app-percona-ns percona-64895d9496-t5jdh --no-headers -o custom-columns=:.status.containerStatuses[*].state.waiting.reason", "delta": "0:00:00.790996", "end": "2021-07-27 09:10:39.178213", "rc": 0, "start": "2021-07-27 09:10:38.387217", "stderr": "", "stderr_lines": [], "stdout": "ContainerCreating", "stdout_lines": ["ContainerCreating"]}

TASK [Obtain the error message from the scaled app pod] ************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:155
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: 'Volume {{ pv_name }} still mounted on node {{
app_node_name }}' in error_status.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl describe pod -n app-percona-ns percona-64895d9496-t5jdh | grep \"Volume pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2 still mounted on node d2iq-node2\"", "delta": "0:00:00.814230", "end": "2021-07-27 09:10:40.182971", "rc": 0, "start": "2021-07-27 09:10:39.368741", "stderr": "", "stderr_lines": [], "stdout": "  Warning  FailedMount  0s (x3 over 0s)  kubelet, d2iq-node5  MountVolume.MountDevice failed for volume \"pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2\" : rpc error: code = Internal desc = Volume pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2 still mounted on node d2iq-node2", "stdout_lines": ["  Warning  FailedMount  0s (x3 over 0s)  kubelet, d2iq-node5  MountVolume.MountDevice failed for volume \"pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2\" : rpc error: code = Internal desc = Volume pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2 still mounted on node d2iq-node2"]}

TASK [include_tasks] ***********************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:168
included: /e2e-tests/chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /e2e-tests/chaoslib/vmware_chaos/vm_power_operations.yml:10
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.43.1.1 vim-cmd vmsvc/getallvms | awk '{print $1 \" \" $2}' | grep d2iq-node2 | awk '{print $1}'", "delta": "0:00:01.507702", "end": "2021-07-27 09:10:41.949826", "rc": 0, "start": "2021-07-27 09:10:40.442124", "stderr": "Warning: Permanently added '10.43.1.1' (RSA) to the list of known hosts.", "stderr_lines": ["Warning: Permanently added '10.43.1.1' (RSA) to the list of known hosts."], "stdout": "17", "stdout_lines": ["17"]}

TASK [Perform operation on the target vm] **************************************
task path: /e2e-tests/chaoslib/vmware_chaos/vm_power_operations.yml:16
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.43.1.1 vim-cmd vmsvc/power.off 17", "delta": "0:00:03.150293", "end": "2021-07-27 09:10:45.289380", "failed_when_result": false, "rc": 0, "start": "2021-07-27 09:10:42.139087", "stderr": "", "stderr_lines": [], "stdout": "Powering off VM:", "stdout_lines": ["Powering off VM:"]}

TASK [Check the node status] ***************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:175
FAILED - RETRYING: Check the node status (30 retries left).
FAILED - RETRYING: Check the node status (29 retries left).
changed: [127.0.0.1] => {"attempts": 3, "changed": true, "cmd": "kubectl get nodes d2iq-node2 --no-headers", "delta": "0:00:00.813885", "end": "2021-07-27 09:11:18.273962", "rc": 0, "start": "2021-07-27 09:11:17.460077", "stderr": "", "stderr_lines": [], "stdout": "d2iq-node2   NotReady   <none>   136d   v1.19.7", "stdout_lines": ["d2iq-node2   NotReady   <none>   136d   v1.19.7"]}

TASK [Wait for the application pod to get evicted] *****************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:185
ok: [127.0.0.1] => {"changed": false, "elapsed": 300, "path": null, "port": null, "search_regex": null, "state": "started"}

TASK [check the application pod event after scale down] ************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:189
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl describe pod -n app-percona-ns percona-64895d9496-9gv8t | grep \"Node is not ready\"", "delta": "0:00:00.847863", "end": "2021-07-27 09:16:19.745785", "rc": 0, "start": "2021-07-27 09:16:18.897922", "stderr": "", "stderr_lines": [], "stdout": "  Warning  NodeNotReady  5m11s              node-controller      Node is not ready", "stdout_lines": ["  Warning  NodeNotReady  5m11s              node-controller      Node is not ready"]}

TASK [check the application status] ********************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:201
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns percona-64895d9496-t5jdh --no-headers -o custom-columns=:.status.phase", "delta": "0:00:00.811305", "end": "2021-07-27 09:16:20.730948", "rc": 0, "start": "2021-07-27 09:16:19.919643", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Check if the CVRs are in healthy state] **********************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:211
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get cvr -n openebs -l openebs.io/persistent-volume=pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2 -o custom-columns=:.status.phase --no-headers", "delta": "0:00:00.803801", "end": "2021-07-27 09:16:21.720160", "rc": 0, "start": "2021-07-27 09:16:20.916359", "stderr": "", "stderr_lines": [], "stdout": "Healthy\nHealthy\nHealthy", "stdout_lines": ["Healthy", "Healthy", "Healthy"]}

TASK [include_tasks] ***********************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:223
included: /e2e-tests/chaoslib/vmware_chaos/vm_power_operations.yml for 127.0.0.1

TASK [Obtain the VM ID] ********************************************************
task path: /e2e-tests/chaoslib/vmware_chaos/vm_power_operations.yml:10
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.43.1.1 vim-cmd vmsvc/getallvms | awk '{print $1 \" \" $2}' | grep d2iq-node2 | awk '{print $1}'", "delta": "0:00:06.106391", "end": "2021-07-27 09:16:28.073501", "rc": 0, "start": "2021-07-27 09:16:21.967110", "stderr": "", "stderr_lines": [], "stdout": "17", "stdout_lines": ["17"]}

TASK [Perform operation on the target vm] **************************************
task path: /e2e-tests/chaoslib/vmware_chaos/vm_power_operations.yml:16
changed: [127.0.0.1] => {"changed": true, "cmd": "sshpass -p password ssh -o StrictHostKeyChecking=no root@10.43.1.1 vim-cmd vmsvc/power.on 17", "delta": "0:00:02.073114", "end": "2021-07-27 09:16:30.310442", "failed_when_result": false, "rc": 0, "start": "2021-07-27 09:16:28.237328", "stderr": "", "stderr_lines": [], "stdout": "Powering on VM:", "stdout_lines": ["Powering on VM:"]}

TASK [Get Running Application pod Node] ****************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:232
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl get pod percona-64895d9496-t5jdh -n app-percona-ns --no-headers -o custom-columns=:spec.nodeName", "delta": "0:00:00.812455", "end": "2021-07-27 09:16:31.285409", "rc": 0, "start": "2021-07-27 09:16:30.472954", "stderr": "", "stderr_lines": [], "stdout": "d2iq-node5", "stdout_lines": ["d2iq-node5"]}

TASK [Record the application pod node name] ************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:240
ok: [127.0.0.1] => {"ansible_facts": {"scaled_app_node_name": "d2iq-node5"}, "changed": false}

TASK [Obtain the error message from the scaled app pod] ************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:244
 [WARNING]: when statements should not include jinja2 templating delimiters
such as {{ }} or {% %}. Found: 'Volume {{ pv_name }} still mounted on node {{
scaled_app_node_name }}' in error_status.stdout
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl describe pod -n app-percona-ns percona-64895d9496-9gv8t | grep \"Volume pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2 still mounted on node d2iq-node5\"", "delta": "0:00:00.835804", "end": "2021-07-27 09:16:32.328046", "rc": 0, "start": "2021-07-27 09:16:31.492242", "stderr": "", "stderr_lines": [], "stdout": "  Warning  FailedMount   15m (x4 over 15m)  kubelet, d2iq-node2  MountVolume.MountDevice failed for volume \"pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2\" : rpc error: code = Internal desc = Volume pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2 still mounted on node d2iq-node5", "stdout_lines": ["  Warning  FailedMount   15m (x4 over 15m)  kubelet, d2iq-node2  MountVolume.MountDevice failed for volume \"pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2\" : rpc error: code = Internal desc = Volume pvc-f374e844-d40e-4efd-b8ce-cc72c508b9b2 still mounted on node d2iq-node5"]}

TASK [Checking application pod is in running state] ****************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml:3
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-64895d9496-t5jdh\")].status.phase}'", "delta": "0:00:00.812212", "end": "2021-07-27 09:16:33.320225", "rc": 0, "start": "2021-07-27 09:16:32.508013", "stderr": "", "stderr_lines": [], "stdout": "Running", "stdout_lines": ["Running"]}

TASK [Get the container status of application.] ********************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml:10
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl get pods -n app-percona-ns -o jsonpath='{.items[?(@.metadata.name==\"percona-64895d9496-t5jdh\")].status.containerStatuses[].state}' | grep running", "delta": "0:00:00.821502", "end": "2021-07-27 09:16:34.317517", "rc": 0, "start": "2021-07-27 09:16:33.496015", "stderr": "", "stderr_lines": [], "stdout": "map[running:map[startedAt:2021-07-27T09:14:58Z]]", "stdout_lines": ["map[running:map[startedAt:2021-07-27T09:14:58Z]]"]}

TASK [Check if db is ready for connections] ************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml:20
changed: [127.0.0.1] => {"attempts": 1, "changed": true, "cmd": "kubectl logs percona-64895d9496-t5jdh -n app-percona-ns | grep 'ready for connections'", "delta": "0:00:00.822899", "end": "2021-07-27 09:16:35.336696", "rc": 0, "start": "2021-07-27 09:16:34.513797", "stderr": "", "stderr_lines": [], "stdout": "2021-07-27T09:15:00.882016Z 0 [Note] mysqld: ready for connections.", "stdout_lines": ["2021-07-27T09:15:00.882016Z 0 [Note] mysqld: ready for connections."]}

TASK [Checking for the Corrupted tables] ***************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml:27
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-64895d9496-t5jdh -n app-percona-ns -- mysqlcheck -c tdb -uroot -pk8sDem0", "delta": "0:00:01.134319", "end": "2021-07-27 09:16:36.652221", "failed_when_result": false, "rc": 0, "start": "2021-07-27 09:16:35.517902", "stderr": "mysqlcheck: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysqlcheck: [Warning] Using a password on the command line interface can be insecure."], "stdout": "tdb.ttbl                                           OK", "stdout_lines": ["tdb.ttbl                                           OK"]}

TASK [Verify mysql data persistence] *******************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml:36
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl exec percona-64895d9496-t5jdh -n app-percona-ns -- mysql -uroot -pk8sDem0 -e 'select * from ttbl' tdb;", "delta": "0:00:00.939530", "end": "2021-07-27 09:16:37.768698", "failed_when_result": false, "rc": 0, "start": "2021-07-27 09:16:36.829168", "stderr": "mysql: [Warning] Using a password on the command line interface can be insecure.", "stderr_lines": ["mysql: [Warning] Using a password on the command line interface can be insecure."], "stdout": "Data\ntdata", "stdout_lines": ["Data", "tdata"]}

TASK [Checking application pod is in running state] ****************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml:49
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Get the container status of application.] ********************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml:56
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Check the md5sum of stored data file] ************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml:66
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Verify whether data is consistent] ***************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/data_availability_check.yml:75
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [set_fact] ****************************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:263
ok: [127.0.0.1] => {"ansible_facts": {"flag": "Pass"}, "changed": false}

TASK [include_tasks] ***********************************************************
task path: /e2e-tests/experiments/infra-chaos/multiple_deployment/test.yml:273
included: /e2e-tests/utils/fcm/update_e2e_result_resource.yml for 127.0.0.1

TASK [Generate the e2e result CR to reflect SOT (Start of Test)] ***************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:3
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Analyze the cr yaml] *****************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:14
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Apply the e2e result CR] *************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:17
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional result was False"}

TASK [Generate the e2e result CR to reflect EOT (End of Test)] *****************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:27
changed: [127.0.0.1] => {"changed": true, "checksum": "54225c7d87c2be994894dd804f6ae92dbac55991", "dest": "./e2e-result.yaml", "gid": 0, "group": "root", "md5sum": "132c207298b979c7464b38909b856f5d", "mode": "0644", "owner": "root", "size": 414, "src": "/root/.ansible/tmp/ansible-tmp-1627377398.24-222186117125333/source", "state": "file", "uid": 0}

TASK [Analyze the cr yaml] *****************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:38
changed: [127.0.0.1] => {"changed": true, "cmd": "cat e2e-result.yaml", "delta": "0:00:00.677399", "end": "2021-07-27 09:16:40.712585", "rc": 0, "start": "2021-07-27 09:16:40.035186", "stderr": "", "stderr_lines": [], "stdout": "---\napiVersion: e2e.io/v1alpha1\nkind: E2eResult\nmetadata:\n\n  # name of the e2e testcase\n  name: node-failure \nspec:\n\n  # holds information on the testcase\n  testMetadata:\n    app:  \n    chaostype: node-failure \n\n  # holds the state of testcase,  manually updated by json merge patch\n  # result is the useful value today, but anticipate phase use in future \n  testStatus: \n    phase: completed  \n    result: Pass ", "stdout_lines": ["---", "apiVersion: e2e.io/v1alpha1", "kind: E2eResult", "metadata:", "", "  # name of the e2e testcase", "  name: node-failure ", "spec:", "", "  # holds information on the testcase", "  testMetadata:", "    app:  ", "    chaostype: node-failure ", "", "  # holds the state of testcase,  manually updated by json merge patch", "  # result is the useful value today, but anticipate phase use in future ", "  testStatus: ", "    phase: completed  ", "    result: Pass "]}

TASK [Apply the e2e result CR] *************************************************
task path: /e2e-tests/utils/fcm/update_e2e_result_resource.yml:41
changed: [127.0.0.1] => {"changed": true, "cmd": "kubectl apply -f e2e-result.yaml", "delta": "0:00:00.995429", "end": "2021-07-27 09:16:41.895352", "failed_when_result": false, "rc": 0, "start": "2021-07-27 09:16:40.899923", "stderr": "", "stderr_lines": [], "stdout": "e2eresult.e2e.io/node-failure configured", "stdout_lines": ["e2eresult.e2e.io/node-failure configured"]}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=53   changed=35   unreachable=0    failed=0 
```
