### PR TITLE
chore(operator): bump k8s csi sidecars images

### DIFF
--- a/deploy/csi-operator.yaml
+++ b/deploy/csi-operator.yaml
@@ -967,7 +967,7 @@ spec:
       serviceAccount: openebs-cstor-csi-controller-sa
       containers:
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -997,7 +997,7 @@ spec:
             - "--leader-election=false"
           imagePullPolicy: IfNotPresent
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -1222,7 +1222,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.12.0
+version: 2.12.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.12.0

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -129,12 +129,12 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | csiController.provisioner.image.pullPolicy | string | `"IfNotPresent"` | CSI provisioner image pull policy |
 | csiController.provisioner.image.registry | string | `"k8s.gcr.io/"` | CSI provisioner image pull registry |
 | csiController.provisioner.image.repository | string | `"sig-storage/csi-provisioner"` | CSI provisioner image pull repository |
-| csiController.provisioner.image.tag | string | `"v2.1.0"` | CSI provisioner image tag |
+| csiController.provisioner.image.tag | string | `"v3.0.0"` | CSI provisioner image tag |
 | csiController.provisioner.name | string | `"csi-provisioner"` | CSI provisioner container name |
 | csiController.resizer.image.pullPolicy | string | `"IfNotPresent"` | CSI resizer image pull policy  |
 | csiController.resizer.image.registry | string | `"k8s.gcr.io/"` | CSI resizer image registry |
 | csiController.resizer.image.repository | string | `"sig-storage/csi-resizer"` |  CSI resizer image repository|
-| csiController.resizer.image.tag | string | `"v1.1.0"` | CSI resizer image tag |
+| csiController.resizer.image.tag | string | `"v1.2.0"` | CSI resizer image tag |
 | csiController.resizer.name | string | `"csi-resizer"` | CSI resizer container name |
 | csiController.resources | object | `{}` | CSI controller container resources |
 | csiController.securityContext | object | `{}` | CSI controller security context |
@@ -154,7 +154,7 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | csiNode.driverRegistrar.image.pullPolicy | string | `"IfNotPresent"` | CSI Node driver registrar image pull policy|
 | csiNode.driverRegistrar.image.registry | string | `"k8s.gcr.io/"` | CSI Node driver registrar image registry |
 | csiNode.driverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | CSI Node driver registrar image repository |
-| csiNode.driverRegistrar.image.tag | string | `"v2.1.0"` |  CSI Node driver registrar image tag|
+| csiNode.driverRegistrar.image.tag | string | `"v2.3.0"` |  CSI Node driver registrar image tag|
 | csiNode.driverRegistrar.name | string | `"csi-node-driver-registrar"` | CSI Node driver registrar container name |
 | csiNode.kubeletDir | string | `"/var/lib/kubelet/"` | Kubelet root dir |
 | csiNode.labels | object | `{}` | CSI Node pod labels |

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -100,7 +100,7 @@ csiController:
       repository: sig-storage/csi-resizer
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
-      tag: v1.1.0
+      tag: v1.2.0
   snapshotter:
     name: "csi-snapshotter"
     image:
@@ -140,7 +140,7 @@ csiController:
       repository: sig-storage/csi-provisioner
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
-      tag: v2.1.0
+      tag: v3.0.0
   annotations: {}
   podAnnotations: {}
   podLabels: {}
@@ -173,7 +173,7 @@ csiNode:
       repository: sig-storage/csi-node-driver-registrar
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
-      tag: v2.1.0
+      tag: v2.3.0
   updateStrategy:
     type: RollingUpdate
   annotations: {}


### PR DESCRIPTION
Update the k8s csi sidecar images to support minimum k8s 1.20.x version.

- CSI Provisioner:
k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0


- CSI Resizer:
k8s.gcr.io/sig-storage/csi-resizer:v1.2.0

- CSI Node Driver Registrar
k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0


**Note**: Keeping  the Snapshotter version as same as earlier , since the latest version only support the V1 snaphot apis , and  cloud k8s distribution, openshift etc does not supported the v1 snapshot APIs yet.

With current snapshotter 3.0.3 version  we have advantage that it will support both v1beta1/v1 apis, which will work in most of the cloud/openshift

Signed-off-by: prateekpandey14 <prateek.pandey@mayadata.io>