### PR TITLE
update(yaml): update priority class name for csi driver

### DIFF
--- a/deploy/csi-operator.yaml
+++ b/deploy/csi-operator.yaml
@@ -923,7 +923,7 @@ roleRef:
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-csi-controller-critical
+  name: openebs-cstor-csi-controller-critical
 value: 900000000
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver controller deployment only."
@@ -931,7 +931,7 @@ description: "This priority class should be used for the CStor CSI driver contro
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: openebs-csi-node-critical
+  name: openebs-cstor-csi-node-critical
 value: 900001000
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver node deployment only."
@@ -963,7 +963,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-controller
         openebs.io/version: dev
     spec:
-      priorityClassName: openebs-csi-controller-critical
+      priorityClassName: openebs-cstor-csi-controller-critical
       serviceAccount: openebs-cstor-csi-controller-sa
       containers:
         - name: csi-resizer
@@ -1217,7 +1217,7 @@ spec:
         openebs.io/component-name: openebs-cstor-csi-node
         openebs.io/version: dev
     spec:
-      priorityClassName: openebs-csi-node-critical
+      priorityClassName: openebs-cstor-csi-node-critical
       serviceAccount: openebs-cstor-csi-node-sa
       hostNetwork: true
       containers:

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.12.1
+version: 2.12.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 2.12.0

--- a/deploy/helm/charts/templates/priority-class.yaml
+++ b/deploy/helm/charts/templates/priority-class.yaml
@@ -3,7 +3,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ template "cstor.csiController.priorityClassName" . }}
-value: 900000000
+value: {{ .Values.csiController.priorityClass.value }}
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver controller deployment only."
 {{- end }}
@@ -13,7 +13,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: {{ template "cstor.csiNode.priorityClassName" . }}
-value: 900001000
+value: {{ .Values.csiNode.priorityClass.value }}
 globalDefault: false
 description: "This priority class should be used for the CStor CSI driver node deployment only."
 {{- end }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -90,6 +90,7 @@ csiController:
   priorityClass:
     create: true
     name: cstor-csi-controller-critical
+    value: 900000000
   componentName: "openebs-cstor-csi-controller"
   resizer:
     name: "csi-resizer"
@@ -165,6 +166,7 @@ csiNode:
   priorityClass:
     create: true
     name: cstor-csi-node-critical
+    value: 900001000
   componentName: "openebs-cstor-csi-node"
   driverRegistrar:
     name: "csi-node-driver-registrar"


### PR DESCRIPTION
use cstor in priority class name to avoid naming clash between different storage engines.

