### PR TITLE
chore(doc): add caution notice while running cStor along with kernel zfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ K8S : 1.18+
 - [Pool and Volume Operations Tutorial](docs/tutorial/intro.md)
 - [FAQ and Troubleshooting](docs/troubleshooting/troubleshooting.md)
 
+
 ## Raising Issues And PRs
 
 If you want to raise any issue for cstor-operators please do that at [openebs/openebs].

--- a/docs/quick.md
+++ b/docs/quick.md
@@ -17,6 +17,20 @@ meets the following prerequisites:
 
 3. You have disks attached to nodes to provision storage.
 
+<h2 style="color:red;"> CAUTION: </h2>
+
+Follow below practice while running cStor along with kernel ZFS on the same set of nodes
+- Disable zfs-import-scan.service service that will avoid importing all pools by scanning all the available devices in the system during boot time, disabling scan service will avoid importing pools that are not created by kernel. Disabling scan service will not cause harm since zfs-import-cache.service is enabled and it is the best way to import pools by looking at cache file during boot time.
+  ```sh
+  sudo systemctl stop zfs-import-scan.service
+  sudo systemctl disable zfs-import-scan.service
+  ```
+- Always maintain upto date /etc/zfs/zpool.cache while performing operations any day2 operations on zfs pools(zpool set cachefile=/etc/zfs/zpool.cache <pool dataset name>).
+
+Note: Following above two step kernel ZFS will not import the pools created by cStor
+
+
+
 ## Install
 
 


### PR DESCRIPTION
Why is this PR required? What issue does it fix?:
This PR reminds the user to be a bit more cautious while running cStor and kernel zfs on the same set of nodes

What this PR does?:
Add caution while running cStor & kernel zfs on the same set of nodes


Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>