### PR TITLE
fix(helm): Make log verbosity configurable

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.1
+version: 3.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.0.0

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -122,19 +122,23 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | csiController.attacher.image.registry | string | `"k8s.gcr.io/"` |  CSI attacher image registry |
 | csiController.attacher.image.repository | string | `"sig-storage/csi-attacher"` |  CSI attacher image repo |
 | csiController.attacher.image.tag | string | `"v3.1.0"` | CSI attacher image tag |
+| csiController.attacher.logLevel | string | _unspecified_ | Override log level for CSI attacher container (1 = least verbose, 5 = most verbose) |
 | csiController.attacher.name | string | `"csi-attacher"` |  CSI attacher container name|
 | csiController.componentName | string | `"openebs-cstor-csi-controller"` | CSI controller component name |
+| csiController.logLevel | string | `"5"` |  Default log level for all CSI controller containers (1 = least verbose, 5 = most verbose) unless overridden for a specific container |
 | csiController.nodeSelector | object | `{}` |  CSI controller pod node selector |
 | csiController.podAnnotations | object | `{}` | CSI controller pod annotations |
 | csiController.provisioner.image.pullPolicy | string | `"IfNotPresent"` | CSI provisioner image pull policy |
 | csiController.provisioner.image.registry | string | `"k8s.gcr.io/"` | CSI provisioner image pull registry |
 | csiController.provisioner.image.repository | string | `"sig-storage/csi-provisioner"` | CSI provisioner image pull repository |
 | csiController.provisioner.image.tag | string | `"v3.0.0"` | CSI provisioner image tag |
+| csiController.provisioner.logLevel | string | _unspecified_ | Override log level for CSI provisioner container (1 = least verbose, 5 = most verbose) |
 | csiController.provisioner.name | string | `"csi-provisioner"` | CSI provisioner container name |
 | csiController.resizer.image.pullPolicy | string | `"IfNotPresent"` | CSI resizer image pull policy  |
 | csiController.resizer.image.registry | string | `"k8s.gcr.io/"` | CSI resizer image registry |
 | csiController.resizer.image.repository | string | `"sig-storage/csi-resizer"` |  CSI resizer image repository|
 | csiController.resizer.image.tag | string | `"v1.2.0"` | CSI resizer image tag |
+| csiController.resizer.logLevel | string | _unspecified_ | Override log level for CSI resizer container (1 = least verbose, 5 = most verbose) |
 | csiController.resizer.name | string | `"csi-resizer"` | CSI resizer container name |
 | csiController.resources | object | `{}` | CSI controller container resources |
 | csiController.securityContext | object | `{}` | CSI controller security context |
@@ -142,6 +146,7 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | csiController.snapshotController.image.registry | string | `"k8s.gcr.io/"` | CSI snapshot controller image registry |
 | csiController.snapshotController.image.repository | string | `"sig-storage/snapshot-controller"` | CSI snapshot controller image repository |
 | csiController.snapshotController.image.tag | string | `"v3.0.3"` | CSI snapshot controller image tag |
+| csiController.snapshotController.logLevel | string | _unspecified_ | Override log level for CSI snapshot controller container (1 = least verbose, 5 = most verbose) |
 | csiController.snapshotController.name | string | `"snapshot-controller"` | CSI snapshot controller container name |
 | csiController.snapshotter.image.pullPolicy | string | `"IfNotPresent"` | CSI snapshotter image pull policy |
 | csiController.snapshotter.image.registry | string | `"k8s.gcr.io/"` | CSI snapshotter image pull registry |
@@ -155,9 +160,11 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | csiNode.driverRegistrar.image.registry | string | `"k8s.gcr.io/"` | CSI Node driver registrar image registry |
 | csiNode.driverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` | CSI Node driver registrar image repository |
 | csiNode.driverRegistrar.image.tag | string | `"v2.3.0"` |  CSI Node driver registrar image tag|
+| csiNode.driverRegistrar.logLevel | string | _unspecified_ | Override log level for CSI node driver registrar container (1 = least verbose, 5 = most verbose) |
 | csiNode.driverRegistrar.name | string | `"csi-node-driver-registrar"` | CSI Node driver registrar container name |
 | csiNode.kubeletDir | string | `"/var/lib/kubelet/"` | Kubelet root dir |
 | csiNode.labels | object | `{}` | CSI Node pod labels |
+| csiNode.logLevel | string | `"5"` | Default log level for CSI node containers (1 = least verbose, 5 = most verbose) unless overriden for a specific container |
 | csiNode.nodeSelector | object | `{}` |   CSI Node pod nodeSelector |
 | csiNode.podAnnotations | object | `{}` | CSI Node pod annotations |
 | csiNode.resources | object | `{}` | CSI Node pod resources |
@@ -197,6 +204,7 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cvcOperator.image.registry | string | `nil` | CVC operator image registry |
 | cvcOperator.image.repository | string | `"openebs/cvc-operator"` | CVC operator image repository |
 | cvcOperator.image.tag | string | `"3.0.0"` | CVC operator image tag |
+| cvcOperator.logLevel | string | `"2"` |  Log level for CVC operator container (1 = least verbose, 5 = most verbose) |
 | cvcOperator.nodeSelector | object | `{}` | CVC operator pod nodeSelector |
 | cvcOperator.podAnnotations | object | `{}` | CVC operator pod annotations |
 | cvcOperator.resources | object | `{}` |CVC operator pod resources  |

--- a/deploy/helm/charts/templates/csi-controller.yaml
+++ b/deploy/helm/charts/templates/csi-controller.yaml
@@ -29,7 +29,7 @@ spec:
           resources:
 {{ toYaml .Values.csiController.resources | indent 12 }}
           args:
-            - "--v=5"
+            - "--v={{ .Values.csiController.resizer.logLevel | default .Values.csiController.logLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--leader-election"
           env:
@@ -53,7 +53,7 @@ spec:
         - name: {{ .Values.csiController.snapshotController.name }}
           image: "{{ .Values.csiController.snapshotController.image.registry }}{{ .Values.csiController.snapshotController.image.repository }}:{{ .Values.csiController.snapshotController.image.tag }}"
           args:
-            - "--v=5"
+            - "--v={{ .Values.csiController.snapshotController.logLevel | default .Values.csiController.logLevel }}"
             - "--leader-election=false"
           imagePullPolicy: {{ .Values.csiController.snapshotController.image.pullPolicy }}
         - name: {{ .Values.csiController.provisioner.name }}
@@ -61,7 +61,7 @@ spec:
           imagePullPolicy: {{ .Values.csiController.provisioner.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--v=5"
+            - "--v={{ .Values.csiController.provisioner.logLevel | default .Values.csiController.logLevel }}"
             - "--feature-gates=Topology=true"
             - "--extra-create-metadata=true"
             - "--metrics-address=:22011"
@@ -81,7 +81,7 @@ spec:
           image: "{{ .Values.csiController.attacher.image.registry }}{{ .Values.csiController.attacher.image.repository }}:{{ .Values.csiController.attacher.image.tag }}"
           imagePullPolicy: {{ .Values.csiController.attacher.image.pullPolicy }}
           args:
-            - "--v=5"
+            - "--v={{ .Values.csiController.attacher.logLevel | default .Values.csiController.logLevel }}"
             - "--csi-address=$(ADDRESS)"
           env:
             - name: ADDRESS

--- a/deploy/helm/charts/templates/csi-node.yaml
+++ b/deploy/helm/charts/templates/csi-node.yaml
@@ -29,7 +29,7 @@ spec:
           resources:
 {{ toYaml .Values.csiNode.resources | indent 12 }}
           args:
-            - "--v=5"
+            - "--v={{ .Values.csiNode.driverRegistrar.logLevel | default .Values.csiNode.logLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
           lifecycle:

--- a/deploy/helm/charts/templates/cvc-operator.yaml
+++ b/deploy/helm/charts/templates/cvc-operator.yaml
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: {{ .Values.cvcOperator.image.pullPolicy }}
           image: "{{ .Values.cvcOperator.image.registry }}{{ .Values.cvcOperator.image.repository }}:{{ .Values.cvcOperator.image.tag }}"
           args:
-            - "--v=2"
+            - "--v={{ .Values.cvcOperator.logLevel }}"
             - "--leader-election=false"
             - "--bind=$(OPENEBS_CVC_POD_IP)"
           resources:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -85,6 +85,7 @@ cvcOperator:
   tolerations: []
   resources: {}
   securityContext: {}
+  logLevel: "2"
 
 csiController:
   priorityClass:
@@ -92,6 +93,7 @@ csiController:
     name: cstor-csi-controller-critical
     value: 900000000
   componentName: "openebs-cstor-csi-controller"
+  logLevel: "5"
   resizer:
     name: "csi-resizer"
     image:
@@ -176,6 +178,7 @@ csiNode:
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
       tag: v2.3.0
+  logLevel: "5"
   updateStrategy:
     type: RollingUpdate
   annotations: {}


### PR DESCRIPTION
A number of components in the helm charts have hard-coded `--v=5` options which can produce overly-verbose logging. I recently submitted openebs/jiva-operator#161 to fix this in the Jiva chart and was asked by @prateekpandey14 to port the same changes here for cStor.

**What this PR does?**:

This PR makes various `--v` flags configurable via the values file/`--set`.  To maintain backwards compatibility the defaults in `values.yaml` remain at the previously hard-coded values but they can now be overridden via

- `csiController.logLevel` to change all the CSI controller containers to the same level in one go.  If this value is not set then we fall back to per-container settings, all of which default to "5"
  - `csiController.attacher.logLevel`
  - `csiController.provisioner.logLevel`
  - `csiController.resizer.logLevel`
  - `csiController.snapshotController.logLevel`
- `csiNode.logLevel` as above for the CSI node pod, though there is only one container-specific child value in this case:
  - `csiNode.driverRegistrar.logLevel` for the node pod driver registrar
- `cvcOperator.logLevel` for the CVC operator (default level 2)

---

**Edit**: following discussion this has now been changed so that the top-level per-pod settings provide the defaults in `values.yaml`, and the per-container settings can be supplied to override the default.

---

**Note** I have only added options for those cases where there is already a `--v` option specified in the helm template.  There may be other components that _could_ accept `--v` but where the chart does not currently pass one, but I don't use cStor myself (this PR is a port of changes I made to Jiva) and don't know the code so I've limited myself to the obviously non-breaking changes.

**Does this PR require any upgrade changes?**:

No
