### PR TITLE
update(helm): allow setting different base dir(and others) for cspc and cvc operators

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.2
+version: 3.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.0.0

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,7 +4,7 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.1
+version: 3.0.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 appVersion: 3.0.0

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -192,8 +192,8 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cspcOperator.resyncInterval | string | `"30"` | CSPC operator resync interval |
 | cspcOperator.securityContext | object | `{}` | CSPC operator security context |
 | cspcOperator.tolerations | list | `[]` | CSPC operator pod tolerations |
-| cspcOperator.baseDir | string | `"/var/openebs"` | CSPC operator base directory for openebs on host path |
-| cspcOperator.cstorPoolSparseDir | string | `"/var/openebs/sparse"` | cStor pool sparse directory for sparse devices |
+| cspcOperator.baseDir | string | `"/var/openebs"` | base directory for openebs cStor pools on host path to store pool related information |
+| cspcOperator.SparseDir | string | `"/var/openebs/sparse"` | sparse directory to access sparse based devices |
 | cstorCSIPlugin.image.pullPolicy | string | `"IfNotPresent"` | CStor CSI driver image pull policy |
 | cstorCSIPlugin.image.registry | string | `nil` | CStor CSI driver image registry |
 | cstorCSIPlugin.image.repository | string | `"openebs/cstor-csi-driver"` |  CStor CSI driver image repository |
@@ -223,8 +223,6 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cvcOperator.volumeMgmt.image.repository | string | `"openebs/cstor-volume-manager"` | Volume mgmt image repository |
 | cvcOperator.volumeMgmt.image.tag | string | `"3.0.0"` |  Volume mgmt image tag|
 | cvcOperator.baseDir | string | `"/var/openebs"` | CVC operator base directory for openebs on host path |
-| cvcOperator.cstorTargetDir | string | `"/var/openebs/sparse"` | cStor target directory for dumping cStor volume |
-| useVarDirectoryPath | bool | `false` | Default hostpath storage for OpenEBS related files |
 | imagePullSecrets | string | `nil` | Image registry pull secrets |
 | openebsNDM.enabled | bool | `true` | Enable OpenEBS NDM dependency |
 | openebs-ndm.featureGates.APIService.enabled | bool | `true` | Enable 'API Service' feature gate for NDM |

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -193,7 +193,7 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cspcOperator.securityContext | object | `{}` | CSPC operator security context |
 | cspcOperator.tolerations | list | `[]` | CSPC operator pod tolerations |
 | cspcOperator.baseDir | string | `"/var/openebs"` | base directory for openebs cStor pools on host path to store pool related information |
-| cspcOperator.SparseDir | string | `"/var/openebs/sparse"` | sparse directory to access sparse based devices |
+| cspcOperator.sparseDir | string | `"/var/openebs/sparse"` | sparse directory to access sparse based devices |
 | cstorCSIPlugin.image.pullPolicy | string | `"IfNotPresent"` | CStor CSI driver image pull policy |
 | cstorCSIPlugin.image.registry | string | `nil` | CStor CSI driver image registry |
 | cstorCSIPlugin.image.repository | string | `"openebs/cstor-csi-driver"` |  CStor CSI driver image repository |

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -185,6 +185,8 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cspcOperator.resyncInterval | string | `"30"` | CSPC operator resync interval |
 | cspcOperator.securityContext | object | `{}` | CSPC operator security context |
 | cspcOperator.tolerations | list | `[]` | CSPC operator pod tolerations |
+| cspcOperator.baseDir | string | `"/var/openebs"` | CSPC operator base directory for openebs on host path |
+| cspcOperator.cstorPoolSparseDir | string | `"/var/openebs/sparse"` | cStor pool sparse directory for sparse devices |
 | cstorCSIPlugin.image.pullPolicy | string | `"IfNotPresent"` | CStor CSI driver image pull policy |
 | cstorCSIPlugin.image.registry | string | `nil` | CStor CSI driver image registry |
 | cstorCSIPlugin.image.repository | string | `"openebs/cstor-csi-driver"` |  CStor CSI driver image repository |
@@ -212,6 +214,9 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cvcOperator.volumeMgmt.image.registry | string | `nil` | Volume mgmt image registry |
 | cvcOperator.volumeMgmt.image.repository | string | `"openebs/cstor-volume-manager"` | Volume mgmt image repository |
 | cvcOperator.volumeMgmt.image.tag | string | `"3.0.0"` |  Volume mgmt image tag|
+| cvcOperator.baseDir | string | `"/var/openebs"` | CVC operator base directory for openebs on host path |
+| cvcOperator.cstorTargetDir | string | `"/var/openebs/sparse"` | cStor target directory for dumping cStor volume |
+| useVarDirectoryPath | bool | `false` | Default hostpath storage for OpenEBS related files |
 | imagePullSecrets | string | `nil` | Image registry pull secrets |
 | openebsNDM.enabled | bool | `true` | Enable OpenEBS NDM dependency |
 | openebs-ndm.featureGates.APIService.enabled | bool | `true` | Enable 'API Service' feature gate for NDM |

--- a/deploy/helm/charts/templates/cspc-operator.yaml
+++ b/deploy/helm/charts/templates/cspc-operator.yaml
@@ -45,18 +45,20 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-{{- if .Values.useVarDirectoryPath }}
+{{- if .Values.cspcOperator.baseDir }}
             # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
             # Where OpenEBS can store required files. Default base path will be /var/openebs
             - name: OPENEBS_IO_BASE_DIR
-              value: "{{ .Values.cspcOperator.baseDir }}"
+              value: {{ .Values.cspcOperator.baseDir | quote }}
+{{- end }}
+{{- if .Values.cspcOperator.SparseDir }}
             # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
             # to be used for saving the shared content between the side cars
             # of cstor pool pod. This ENV is also used to indicate the location
             # of the sparse devices.
             # The default path used is /var/openebs/sparse
             - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
-              value: "{{ .Values.cspcOperator.cstorPoolSparseDir }}"
+              value: "{{ .Values.cspcOperator.SparseDir }}"
 {{- end }}
             - name: OPENEBS_IO_CSPI_MGMT_IMAGE
               value: "{{ .Values.cspcOperator.poolManager.image.registry }}{{ .Values.cspcOperator.poolManager.image.repository }}:{{ .Values.cspcOperator.poolManager.image.tag }}"

--- a/deploy/helm/charts/templates/cspc-operator.yaml
+++ b/deploy/helm/charts/templates/cspc-operator.yaml
@@ -51,14 +51,14 @@ spec:
             - name: OPENEBS_IO_BASE_DIR
               value: {{ .Values.cspcOperator.baseDir | quote }}
 {{- end }}
-{{- if .Values.cspcOperator.SparseDir }}
+{{- if .Values.cspcOperator.sparseDir }}
             # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
             # to be used for saving the shared content between the side cars
             # of cstor pool pod. This ENV is also used to indicate the location
             # of the sparse devices.
             # The default path used is /var/openebs/sparse
             - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
-              value: "{{ .Values.cspcOperator.SparseDir }}"
+              value: "{{ .Values.cspcOperator.sparseDir }}"
 {{- end }}
             - name: OPENEBS_IO_CSPI_MGMT_IMAGE
               value: "{{ .Values.cspcOperator.poolManager.image.registry }}{{ .Values.cspcOperator.poolManager.image.repository }}:{{ .Values.cspcOperator.poolManager.image.tag }}"

--- a/deploy/helm/charts/templates/cspc-operator.yaml
+++ b/deploy/helm/charts/templates/cspc-operator.yaml
@@ -45,17 +45,19 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+{{- if .Values.useVarDirectoryPath }}
             # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
             # Where OpenEBS can store required files. Default base path will be /var/openebs
-            # - name: OPENEBS_IO_BASE_DIR
-            #   value: "/var/openebs"
+            - name: OPENEBS_IO_BASE_DIR
+              value: "{{ .Values.cspcOperator.baseDir }}"
             # OPENEBS_IO_CSTOR_POOL_SPARSE_DIR can be used to specify the hostpath
             # to be used for saving the shared content between the side cars
             # of cstor pool pod. This ENV is also used to indicate the location
             # of the sparse devices.
             # The default path used is /var/openebs/sparse
-            #- name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
-            #  value: "/var/openebs/sparse"
+            - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+              value: "{{ .Values.cspcOperator.cstorPoolSparseDir }}"
+{{- end }}
             - name: OPENEBS_IO_CSPI_MGMT_IMAGE
               value: "{{ .Values.cspcOperator.poolManager.image.registry }}{{ .Values.cspcOperator.poolManager.image.repository }}:{{ .Values.cspcOperator.poolManager.image.tag }}"
             - name: OPENEBS_IO_CSTOR_POOL_IMAGE

--- a/deploy/helm/charts/templates/cvc-operator.yaml
+++ b/deploy/helm/charts/templates/cvc-operator.yaml
@@ -34,16 +34,11 @@ spec:
           resources:
 {{ toYaml .Values.cvcOperator.resources | indent 12 }}
           env:
-{{- if .Values.useVarDirectoryPath }}
+{{- if .Values.cvcOperator.baseDir }}
             # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
             # Where OpenEBS can store required files. Default base path will be /var/openebs
             - name: OPENEBS_IO_BASE_DIR
               value: "{{ .Values.cvcOperator.baseDir }}"
-            # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
-            # that to be used for saving the core dump of cstor volume pod.
-            # The default path used is /var/openebs/sparse
-            - name: OPENEBS_IO_CSTOR_TARGET_DIR
-              value: "{{ .Values.cvcOperator.cstorTargetDir }}"
 {{- end }}
             - name: OPENEBS_NAMESPACE
               valueFrom:

--- a/deploy/helm/charts/templates/cvc-operator.yaml
+++ b/deploy/helm/charts/templates/cvc-operator.yaml
@@ -34,15 +34,17 @@ spec:
           resources:
 {{ toYaml .Values.cvcOperator.resources | indent 12 }}
           env:
+{{- if .Values.useVarDirectoryPath }}
             # OPENEBS_IO_BASE_DIR is used to configure base directory for openebs on host path.
             # Where OpenEBS can store required files. Default base path will be /var/openebs
-            # - name: OPENEBS_IO_BASE_DIR
-            #   value: "/var/openebs"
+            - name: OPENEBS_IO_BASE_DIR
+              value: "{{ .Values.cvcOperator.baseDir }}"
             # OPENEBS_IO_CSTOR_TARGET_DIR can be used to specify the hostpath
             # that to be used for saving the core dump of cstor volume pod.
             # The default path used is /var/openebs/sparse
-            #- name: OPENEBS_IO_CSTOR_TARGET_DIR
-            #  value: "/var/openebs/sparse"
+            - name: OPENEBS_IO_CSTOR_TARGET_DIR
+              value: "{{ .Values.cvcOperator.cstorTargetDir }}"
+{{- end }}
             - name: OPENEBS_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -18,6 +18,9 @@ rbac:
 imagePullSecrets:
 # - name: "image-pull-secret"
 
+# If false, then the default hostpath for storing openebs required files will not be used
+useVarDirectoryPath: true
+
 cspcOperator:
   componentName: cspc-operator
   poolManager:
@@ -51,6 +54,8 @@ cspcOperator:
   tolerations: []
   resources: {}
   securityContext: {}
+  baseDir: "/var/openebs"
+  cstorPoolSparseDir: "/var/openebs/sparse"
 
 cvcOperator:
   componentName: cvc-operator
@@ -85,6 +90,8 @@ cvcOperator:
   tolerations: []
   resources: {}
   securityContext: {}
+  baseDir: "/var/openebs"
+  cstorTargetDir: "/var/openebs/sparse"
 
 csiController:
   priorityClass:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -52,7 +52,7 @@ cspcOperator:
   resources: {}
   securityContext: {}
   baseDir: "/var/openebs"
-  SparseDir: "/var/openebs/sparse"
+  sparseDir: "/var/openebs/sparse"
 
 cvcOperator:
   componentName: cvc-operator

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -19,7 +19,7 @@ imagePullSecrets:
 # - name: "image-pull-secret"
 
 # If false, then the default hostpath for storing openebs required files will not be used
-useVarDirectoryPath: true
+useVarDirectoryPath: false
 
 cspcOperator:
   componentName: cspc-operator

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -18,9 +18,6 @@ rbac:
 imagePullSecrets:
 # - name: "image-pull-secret"
 
-# If false, then the default hostpath for storing openebs required files will not be used
-useVarDirectoryPath: false
-
 cspcOperator:
   componentName: cspc-operator
   poolManager:
@@ -55,7 +52,7 @@ cspcOperator:
   resources: {}
   securityContext: {}
   baseDir: "/var/openebs"
-  cstorPoolSparseDir: "/var/openebs/sparse"
+  SparseDir: "/var/openebs/sparse"
 
 cvcOperator:
   componentName: cvc-operator
@@ -91,7 +88,6 @@ cvcOperator:
   resources: {}
   securityContext: {}
   baseDir: "/var/openebs"
-  cstorTargetDir: "/var/openebs/sparse"
   logLevel: "2"
 
 csiController:


### PR DESCRIPTION
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>

**What this PR does?**
Allows setting different hostpath dir paths for OPENEBS_IO_BASE_DIR (and others) in cspc and cvc operator yamls. 

**Which issue does this PR fix?**
issue #396