### PR TITLE
[stable/cStor]: update cStor charts to 3.1.0 release

### DIFF
--- a/deploy/crds/all_cstor_crds.yaml
+++ b/deploy/crds/all_cstor_crds.yaml
@@ -1233,6 +1233,135 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.0
+  creationTimestamp: null
+  name: cstorvolumeattachments.cstor.openebs.io
+spec:
+  group: cstor.openebs.io
+  names:
+    kind: CStorVolumeAttachment
+    listKind: CStorVolumeAttachmentList
+    plural: cstorvolumeattachments
+    shortNames:
+    - cva
+    singular: cstorvolumeattachment
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CStorVolumeAttachment represents a CSI based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CStorVolumeAttachmentSpec is the spec for a CStorVolume resource
+            properties:
+              iscsi:
+                description: ISCSIInfo specific to ISCSI protocol, this is filled
+                  only if the volume type is iSCSI
+                properties:
+                  iqn:
+                    description: Iqn of this volume
+                    type: string
+                  iscsiInterface:
+                    description: IscsiInterface of this volume
+                    type: string
+                  lun:
+                    description: 'Lun specify the lun number 0, 1.. on iSCSI Volume.
+                      (default: 0)'
+                    type: string
+                  targetPortal:
+                    description: TargetPortal holds the target portal of this volume
+                    type: string
+                type: object
+              volume:
+                description: Volume specific info
+                properties:
+                  accessModes:
+                    description: AccessMode of a volume will hold the access mode
+                      of the volume
+                    items:
+                      type: string
+                    type: array
+                  accessType:
+                    description: AccessType of a volume will indicate if the volume
+                      will be used as a block device or mounted on a path
+                    type: string
+                  capacity:
+                    description: Capacity of the volume
+                    type: string
+                  devicePath:
+                    description: Device Path specifies the device path which is returned
+                      when the iSCSI login is successful
+                    type: string
+                  fsType:
+                    description: FSType of a volume will specify the format type -
+                      ext4(default), xfs of PV
+                    type: string
+                  mountOptions:
+                    description: MountOptions specifies the options with which mount
+                      needs to be attempted
+                    items:
+                      type: string
+                    type: array
+                  name:
+                    description: Name of the CSI volume
+                    type: string
+                  ownerNodeID:
+                    description: OwnerNodeID is the Node ID which is also the owner
+                      of this Volume
+                    type: string
+                  readOnly:
+                    description: ReadOnly specifies if the volume needs to be mounted
+                      in ReadOnly mode
+                    type: boolean
+                  stagingTargetPath:
+                    description: StagingPath of the volume will hold the path on which
+                      the volume is mounted on that node
+                    type: string
+                  targetPath:
+                    description: TargetPath of the volume will hold the path on which
+                      the volume is bind mounted on that node
+                    type: string
+                required:
+                - name
+                - ownerNodeID
+                type: object
+            required:
+            - iscsi
+            - volume
+            type: object
+          status:
+            description: CStorVolumeAttachmentStatus status represents the current
+              mount status of the volume
+            type: string
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/deploy/cstor-operator.yaml
+++ b/deploy/cstor-operator.yaml
@@ -1343,7 +1343,6 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -4,10 +4,10 @@ description: CStor-Operator helm chart for Kubernetes
 type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 3.0.3
+version: 3.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 3.0.0
+appVersion: 3.1.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:
@@ -22,7 +22,7 @@ sources:
 
 dependencies:
   - name: openebs-ndm
-    version: "1.7.1"
+    version: "1.8.0"
     repository: "https://openebs.github.io/node-disk-manager"
     condition: openebsNDM.enabled
 

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -52,7 +52,7 @@ By default this chart installs additional, dependent charts:
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://openebs.github.io/node-disk-manager | openebs-ndm | 1.7.1 |
+| https://openebs.github.io/node-disk-manager | openebs-ndm | 1.8.0 |
 
 To disable the dependency during installation, set `openebsNDM.enabled` to `false`.
 
@@ -109,7 +109,7 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | admissionServer.image.pullPolicy | string | `"IfNotPresent"` | Admission webhook image pull policy |
 | admissionServer.image.registry | string | `nil` | Admission webhook image registry |
 | admissionServer.image.repository | string | `"openebs/cstor-webhook"` | Admission webhook image repo |
-| admissionServer.image.tag | string | `"3.0.0"` | Admission webhook image tag |
+| admissionServer.image.tag | string | `"3.1.0"` | Admission webhook image tag |
 | admissionServer.nodeSelector | object | `{}` | Admission webhook pod node selector |
 | admissionServer.podAnnotations | object | `{}` |  Admission webhook pod annotations |
 | admissionServer.resources | object | `{}` | Admission webhook pod resources |
@@ -175,19 +175,19 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cspcOperator.componentName | string | `"cspc-operator"` | CSPC operator component name |
 | cspcOperator.cstorPool.image.registry | string | `nil` | CStor pool image registry |
 | cspcOperator.cstorPool.image.repository | string | `"openebs/cstor-pool"` | CStor pool image repository|
-| cspcOperator.cstorPool.image.tag | string | `"3.0.0"` | CStor pool image tag |
+| cspcOperator.cstorPool.image.tag | string | `"3.1.0"` | CStor pool image tag |
 | cspcOperator.cstorPoolExporter.image.registry | string | `nil` | CStor pool exporter image registry |
 | cspcOperator.cstorPoolExporter.image.repository | string | `"openebs/m-exporter"` | CStor pool exporter image repository |
-| cspcOperator.cstorPoolExporter.image.tag | string | `"3.0.0"` | CStor pool exporter image tag |
+| cspcOperator.cstorPoolExporter.image.tag | string | `"3.1.0"` | CStor pool exporter image tag |
 | cspcOperator.image.pullPolicy | string | `"IfNotPresent"` | CSPC operator image pull policy |
 | cspcOperator.image.registry | string | `nil` | CSPC operator image registry |
 | cspcOperator.image.repository | string | `"openebs/cspc-operator"` | CSPC operator image repository |
-| cspcOperator.image.tag | string | `"3.0.0"` |  CSPC operator image tag |
+| cspcOperator.image.tag | string | `"3.1.0"` |  CSPC operator image tag |
 | cspcOperator.nodeSelector | object | `{}` |  CSPC operator pod nodeSelector|
 | cspcOperator.podAnnotations | object | `{}` | CSPC operator pod annotations |
 | cspcOperator.poolManager.image.registry | string | `nil` | CStor Pool Manager image registry  |
 | cspcOperator.poolManager.image.repository | string | `"openebs/cstor-pool-manager"` | CStor Pool Manager image repository |
-| cspcOperator.poolManager.image.tag | string | `"3.0.0"` | CStor Pool Manager image tag |
+| cspcOperator.poolManager.image.tag | string | `"3.1.0"` | CStor Pool Manager image tag |
 | cspcOperator.resources | object | `{}` | CSPC operator pod resources |
 | cspcOperator.resyncInterval | string | `"30"` | CSPC operator resync interval |
 | cspcOperator.securityContext | object | `{}` | CSPC operator security context |
@@ -197,7 +197,7 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cstorCSIPlugin.image.pullPolicy | string | `"IfNotPresent"` | CStor CSI driver image pull policy |
 | cstorCSIPlugin.image.registry | string | `nil` | CStor CSI driver image registry |
 | cstorCSIPlugin.image.repository | string | `"openebs/cstor-csi-driver"` |  CStor CSI driver image repository |
-| cstorCSIPlugin.image.tag | string | `"3.0.0"` | CStor CSI driver image tag |
+| cstorCSIPlugin.image.tag | string | `"3.1.0"` | CStor CSI driver image tag |
 | cstorCSIPlugin.name | string | `"cstor-csi-plugin"` | CStor CSI driver container name |
 | cstorCSIPlugin.remount | string | `"true"` | Enable/disable auto-remount when volume recovers from read-only state |
 | cvcOperator.annotations | object | `{}` | CVC operator annotations |
@@ -205,7 +205,7 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cvcOperator.image.pullPolicy | string | `"IfNotPresent"` | CVC operator image pull policy  |
 | cvcOperator.image.registry | string | `nil` | CVC operator image registry |
 | cvcOperator.image.repository | string | `"openebs/cvc-operator"` | CVC operator image repository |
-| cvcOperator.image.tag | string | `"3.0.0"` | CVC operator image tag |
+| cvcOperator.image.tag | string | `"3.1.0"` | CVC operator image tag |
 | cvcOperator.logLevel | string | `"2"` |  Log level for CVC operator container (1 = least verbose, 5 = most verbose) |
 | cvcOperator.nodeSelector | object | `{}` | CVC operator pod nodeSelector |
 | cvcOperator.podAnnotations | object | `{}` | CVC operator pod annotations |
@@ -214,14 +214,14 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | cvcOperator.securityContext | object | `{}` | CVC operator security context |
 | cvcOperator.target.image.registry | string | `nil` | Volume Target image registry  |
 | cvcOperator.target.image.repository | string | `"openebs/cstor-istgt"` | Volume Target image repository |
-| cvcOperator.target.image.tag | string | `"3.0.0"` | Volume Target image tag |
+| cvcOperator.target.image.tag | string | `"3.1.0"` | Volume Target image tag |
 | cvcOperator.tolerations | list | `[]` | CVC operator pod tolerations |
 | cvcOperator.volumeExporter.image.registry | string | `nil` | Volume exporter image registry |
 | cvcOperator.volumeExporter.image.repository | string | `"openebs/m-exporter"` | Volume exporter image repository |
-| cvcOperator.volumeExporter.image.tag | string | `"3.0.0"` | Volume exporter image tag |
+| cvcOperator.volumeExporter.image.tag | string | `"3.1.0"` | Volume exporter image tag |
 | cvcOperator.volumeMgmt.image.registry | string | `nil` | Volume mgmt image registry |
 | cvcOperator.volumeMgmt.image.repository | string | `"openebs/cstor-volume-manager"` | Volume mgmt image repository |
-| cvcOperator.volumeMgmt.image.tag | string | `"3.0.0"` |  Volume mgmt image tag|
+| cvcOperator.volumeMgmt.image.tag | string | `"3.1.0"` |  Volume mgmt image tag|
 | cvcOperator.baseDir | string | `"/var/openebs"` | CVC operator base directory for openebs on host path |
 | imagePullSecrets | string | `nil` | Image registry pull secrets |
 | openebsNDM.enabled | bool | `true` | Enable OpenEBS NDM dependency |
@@ -243,7 +243,7 @@ helm install openebs-cstor openebs-cstor/cstor --namespace openebs --create-name
 | openebs-ndm.ndmOperator.image.repository | string | `openebs/node-disk-operator` | Image repository for NDM operator |
 | rbac.create | bool | `true` | Enable RBAC |
 | rbac.pspEnabled | bool | `false` | Enable PodSecurityPolicy |
-| release.version | string | `"3.0.0"` | Openebs CStor release version |
+| release.version | string | `"3.1.0"` | Openebs CStor release version |
 | serviceAccount.annotations | object | `{}` | Service Account annotations |
 | serviceAccount.csiController.create | bool | `true` | Enable CSI Controller ServiceAccount |
 | serviceAccount.csiController.name | string | `"openebs-cstor-csi-controller-sa"` | CSI Controller ServiceAccount name |

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 release:
-  version: "3.0.0"
+  version: "3.1.0"
 
 # If false, openebs NDM sub-chart will not be installed
 openebsNDM:
@@ -24,17 +24,17 @@ cspcOperator:
     image:
       registry:
       repository: openebs/cstor-pool-manager
-      tag: 3.0.0
+      tag: 3.1.0
   cstorPool:
     image:
       registry:
       repository: openebs/cstor-pool
-      tag: 3.0.0
+      tag: 3.1.0
   cstorPoolExporter:
     image:
       registry:
       repository: openebs/m-exporter
-      tag: 3.0.0
+      tag: 3.1.0
   image:
     # Make sure that registry name end with a '/'.
     # For example : quay.io/ is a correct value here and quay.io is incorrect
@@ -42,7 +42,7 @@ cspcOperator:
     repository: openebs/cspc-operator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.0.0
+    tag: 3.1.0
   annotations: {}
   resyncInterval: "30"
   podAnnotations: {}
@@ -60,17 +60,17 @@ cvcOperator:
     image:
       registry:
       repository: openebs/cstor-istgt
-      tag: 3.0.0
+      tag: 3.1.0
   volumeMgmt:
     image:
       registry:
       repository: openebs/cstor-volume-manager
-      tag: 3.0.0
+      tag: 3.1.0
   volumeExporter:
     image:
       registry:
       repository: openebs/m-exporter
-      tag: 3.0.0
+      tag: 3.1.0
   image:
     # Make sure that registry name end with a '/'.
     # For example : quay.io/ is a correct value here and quay.io is incorrect
@@ -78,7 +78,7 @@ cvcOperator:
     repository: openebs/cvc-operator
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.0.0
+    tag: 3.1.0
   annotations: {}
   resyncInterval: "30"
   podAnnotations: {}
@@ -164,7 +164,7 @@ cstorCSIPlugin:
     repository: openebs/cstor-csi-driver
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.0.0
+    tag: 3.1.0
   remount: "true"
 
 csiNode:
@@ -217,7 +217,7 @@ admissionServer:
     repository: openebs/cstor-webhook
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 3.0.0
+    tag: 3.1.0
   failurePolicy: "Fail"
   annotations: {}
   podAnnotations: {}


### PR DESCRIPTION
This PR does the following changes:
- Updates cStor charts to use new 3.1.0 release.
- Adds missing CStorVolumeAttachment CRD into operator YAML.