### PR TITLE
refact(e2e): Scale down the application deployment to single replica

### DIFF
--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test.yml
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test.yml
@@ -260,6 +260,13 @@
             pod_name: "{{ scaled_pod_name.stdout }}"
           when: data_persistence != ''
 
+        - name: Scale down the deployment again to single replica
+          shell: kubectl scale deploy -n {{ namespace }} "{{ app_deploy_name.stdout }}" --replicas=1
+          args:
+            executable: /bin/bash
+          register: scale_deploy
+          failed_when: scale_deploy.rc != 0
+
         - set_fact:
             flag: "Pass"
 

--- a/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test.yml
+++ b/e2e-tests/experiments/infra-chaos/multiple_application_on_single_volume/test.yml
@@ -181,7 +181,7 @@
           delay: 15
           retries: 30
 
-        # wait 5 minutes
+        # wait for 5 minutes
         - name: Wait for the application pod to get evicted
           wait_for:
             timeout: 300


### PR DESCRIPTION
Signed-off-by: Aman Gupta <aman@aman-mbp1.local>
- This PR refactors the multiple app login e2e-test case, where application deployment was scaled up but at the end of test, it was not again scaled down to its original single replica. This makes deprovisioning task failure in pipeline.