### PR TITLE
fix(ci): fix build.yml syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           reporter: github-pr-review
           path: '.'
           pattern: '*.sh'
-          exclude: './.git/*
+          exclude: './.git/*'
 
   unit-tests:
     if: ${{ (github.event.ref_type != 'tag') }}


### PR DESCRIPTION
Signed-off-by: Niladri Halder <niladri.halder26@gmail.com>

This fixes a Github Actions syntax typo introduced in 4e239f0adee2eff4f27a59216738f5f7a0e7e965.