### PR TITLE
fixes #456

### DIFF
--- a/deploy/helm/charts/templates/snapshot-class.yaml
+++ b/deploy/helm/charts/templates/snapshot-class.yaml
@@ -1,9 +1,9 @@
 {{ if or (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1/VolumeSnapshotClass") (.Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshotClass") }}
 kind: VolumeSnapshotClass
-apiVersion: {{ if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1beta1/VolumeSnapshotClass" -}}
-  snapshot.storage.k8s.io/v1beta1
-{{- else -}}
+apiVersion: {{ if .Capabilities.APIVersions.Has "snapshot.storage.k8s.io/v1/VolumeSnapshotClass" -}}
   snapshot.storage.k8s.io/v1
+{{- else -}}
+  snapshot.storage.k8s.io/v1beta1
 {{- end }}
 metadata:
   name: csi-cstor-snapshotclass


### PR DESCRIPTION
Reverse the logic on apiVersion check, should use latest stable `snapshot.storage.k8s.io/v1/VolumeSnapshotClass` if available. 